### PR TITLE
feat(auth): integrate SMTP service for recovery emails; reset flow pending

### DIFF
--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -1,5 +1,6 @@
 from typing import Any
-from fastapi import APIRouter, Depends, HTTPException, status
+from datetime import timedelta
+from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
@@ -7,6 +8,9 @@ from jose import jwt, JWTError
 from app.models.presentation import User
 from app.core.database import AsyncSessionLocal
 from app.core import security
+from app.services import email_service
+from app.schemas.auth import ForgotPassword, ResetPassword
+from app.core.logger import logger
 from app.models import presentation as models
 from app.schemas import auth as schemas
 from app.core.config import settings
@@ -106,3 +110,51 @@ async def get_me(
     Get current user profile information.
     """
     return current_user
+
+
+@router.post("/forgot-password")
+async def forgot_password(
+    payload: ForgotPassword,
+    background_tasks: BackgroundTasks,
+    db: AsyncSession = Depends(get_db)
+) -> Any:
+    """Generates a password-reset token and sends a reset link to the given email.
+    Returns a generic success message regardless of whether the email exists.
+    """
+    result = await db.execute(select(models.User).where(models.User.email == payload.email))
+    user = result.scalar_one_or_none()
+
+    if user:
+        expires = timedelta(minutes=settings.PASSWORD_RESET_TOKEN_EXPIRE_MINUTES)
+        token = security.create_access_token(subject=user.id, expires_delta=expires)
+        background_tasks.add_task(email_service.send_password_reset_email, user.email, token)
+    else:
+        logger.warning(f"Password reset requested for unknown email: {payload.email}")
+
+    return {"msg": "If that email exists, a password reset link has been sent."}
+
+
+@router.post("/reset-password")
+async def reset_password(
+    payload: ResetPassword,
+    db: AsyncSession = Depends(get_db)
+) -> Any:
+    """Resets the user's password using a valid token and new password."""
+    try:
+        data = jwt.decode(payload.token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+        user_id: str = data.get("sub")
+        if user_id is None:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid token")
+    except JWTError:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid token")
+
+    result = await db.execute(select(models.User).where(models.User.id == int(user_id)))
+    user = result.scalar_one_or_none()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    user.password_hash = security.get_password_hash(payload.new_password)
+    db.add(user)
+    await db.commit()
+
+    return {"msg": "Password has been reset successfully."}

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -19,6 +19,20 @@ class Settings(BaseSettings):
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
 
+    # Password reset configuration
+    PASSWORD_RESET_TOKEN_EXPIRE_MINUTES: int = 60
+
+    # Frontend URL used to build password reset links
+    FRONTEND_URL: str = Field(default="http://localhost:3000", description="Frontend base URL for reset links")
+
+    # SMTP / Email settings (used for sending password reset emails)
+    SMTP_HOST: str | None = None
+    SMTP_PORT: int | None = None
+    SMTP_USER: str | None = None
+    SMTP_PASSWORD: str | None = None
+    SMTP_FROM_EMAIL: str | None = None
+    SMTP_FROM_NAME: str | None = None
+
     # CORS configuration
     CORS_ORIGINS: list[str] = Field(
         default=["http://localhost:3000"],

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -35,3 +35,19 @@ class UserResponse(BaseModel):
     is_active: bool = True
     
     model_config = ConfigDict(from_attributes=True)
+
+class ForgotPassword(BaseModel):
+    email: EmailStr
+
+
+class ResetPassword(BaseModel):
+    token: str
+    new_password: str = Field(..., min_length=8)
+    new_password_confirm: str
+
+    @field_validator('new_password_confirm')
+    @classmethod
+    def passwords_match(cls, v: str, info):
+        if 'new_password' in info.data and v != info.data['new_password']:
+            raise ValueError('Passwords do not match!')
+        return v

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -1,0 +1,45 @@
+from email.message import EmailMessage
+from typing import Optional
+import aiosmtplib
+from app.core.config import settings
+from app.core.logger import logger
+
+
+async def send_password_reset_email(to_email: str, token: str) -> bool:
+    """Send a simple password reset email containing a link with the token.
+
+    Returns True on success, False on failure.
+    """
+    if not settings.SMTP_HOST or not settings.SMTP_PORT:
+        logger.error("SMTP not configured; cannot send email")
+        return False
+
+    reset_url = f"{settings.FRONTEND_URL.rstrip('/')}/reset-password?token={token}"
+
+    message = EmailMessage()
+    from_header = settings.SMTP_FROM_EMAIL or settings.SMTP_USER or "no-reply@localhost"
+    if settings.SMTP_FROM_NAME:
+        message["From"] = f"{settings.SMTP_FROM_NAME} <{from_header}>"
+    else:
+        message["From"] = from_header
+
+    message["To"] = to_email
+    message["Subject"] = "Password Reset Request"
+
+    body = f"You requested a password reset. Click the link below to reset your password:\n\n{reset_url}\n\nIf you didn't request this, you can safely ignore this email."
+    message.set_content(body)
+
+    try:
+        await aiosmtplib.send(
+            message,
+            hostname=settings.SMTP_HOST,
+            port=int(settings.SMTP_PORT),
+            start_tls=True,
+            username=settings.SMTP_USER,
+            password=settings.SMTP_PASSWORD,
+        )
+        logger.info(f"Sent password reset email to {to_email}")
+        return True
+    except Exception as e:
+        logger.error(f"Failed to send password reset email to {to_email}: {e}")
+        return False

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -25,3 +25,4 @@ aiosqlite
 flake8
 bandit
 safety
+aiosmtplib

--- a/backend/scripts/test_smtp.py
+++ b/backend/scripts/test_smtp.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Simple script to test SMTP connectivity and authentication.
+
+Usage:
+  python scripts/test_smtp.py --to recipient@example.com
+
+It reads SMTP settings from environment variables (or .env when available).
+"""
+import os
+import argparse
+import smtplib
+from email.message import EmailMessage
+from dotenv import load_dotenv
+
+
+def main():
+    load_dotenv()
+
+    smtp_host = os.environ.get("SMTP_HOST")
+    smtp_port = int(os.environ.get("SMTP_PORT") or 0)
+    smtp_user = os.environ.get("SMTP_USER")
+    smtp_password = os.environ.get("SMTP_PASSWORD")
+    from_email = os.environ.get("SMTP_FROM_EMAIL") or smtp_user
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--to", required=True, help="Recipient email address to send test message to")
+    args = parser.parse_args()
+
+    print("SMTP settings:")
+    print(f"  host={smtp_host}")
+    print(f"  port={smtp_port}")
+    print(f"  user={smtp_user}")
+
+    if not smtp_host or not smtp_port:
+        print("ERROR: SMTP_HOST or SMTP_PORT not configured in environment (.env).")
+        return
+
+    msg = EmailMessage()
+    msg["From"] = from_email
+    msg["To"] = args.to
+    msg["Subject"] = "Test SMTP message"
+    msg.set_content("This is a test message sent by scripts/test_smtp.py to validate SMTP settings.")
+
+    try:
+        with smtplib.SMTP(smtp_host, smtp_port, timeout=10) as server:
+            server.set_debuglevel(1)
+            server.ehlo()
+            # Try STARTTLS if server supports it
+            try:
+                server.starttls()
+                server.ehlo()
+            except Exception as e:
+                print(f"STARTTLS not used / failed: {e}")
+            if smtp_user and smtp_password:
+                try:
+                    server.login(smtp_user, smtp_password)
+                except Exception as e:
+                    print("Authentication failed:", e)
+                    return
+            server.send_message(msg)
+            print("Test email sent successfully.")
+    except Exception as e:
+        print("Failed to send test email:", e)
+
+
+if __name__ == "__main__":
+    main()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,13 @@ services:
     environment:
       - DATABASE_URL=postgresql+asyncpg://${DB_USER:-admin}:${DB_PASSWORD:-admin}@db:5432/${DB_NAME:-presentation_db}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - SMTP_HOST=${SMTP_HOST}
+      - SMTP_PORT=${SMTP_PORT}
+      - SMTP_USER=${SMTP_USER}
+      - SMTP_PASSWORD=${SMTP_PASSWORD}
+      - SMTP_FROM_EMAIL=${SMTP_FROM_EMAIL}
+      - SMTP_FROM_NAME=${SMTP_FROM_NAME}
+      - FRONTEND_URL=${FRONTEND_URL}
     depends_on:
       - db
     networks:


### PR DESCRIPTION
forgot-password endpoint token üretiyor ve e‑posta başarıyla teslim ediliyor.
E‑postadaki reset linki kullanıcıya ulaşıyor fakat şu an link tıklanınca şifre sıfırlama işlemi tamamlanmıyor.
Muhtemel nedenler: frontend reset sayfası token parametresini POST ile POST /api/v1/auth/reset-password endpoint’ine göndermiyor veya backend token doğrulama/uyumluluk beklentisi ile frontend formatı farklı.