### PR TITLE
53 session records and profile settings in dashboard

### DIFF
--- a/backend/app/api/v1/orchestration.py
+++ b/backend/app/api/v1/orchestration.py
@@ -1,11 +1,17 @@
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Depends
-from typing import Dict, List
+from typing import Dict, List, Optional
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 import json
 from app.services import intent_service
+from app.services.session_records_service import (
+    end_live_session,
+    resolve_user_id_from_token,
+    start_live_session,
+)
 from app.core.logger import logger
 from app.core.database import AsyncSessionLocal
 from app.models.presentation import PresentationSession, Base
-from sqlalchemy import select, update, text
+from sqlalchemy import update
 
 router = APIRouter()
 
@@ -51,6 +57,9 @@ manager = ConnectionManager()
 async def websocket_orchestration(websocket: WebSocket, presentation_id: str):
     logger.info(f"[WebSocket Handshake] Start for presentation_id: {presentation_id}")
     logger.debug(f"Loaded tables: {list(Base.metadata.tables.keys())}")
+    user_id: Optional[int] = await resolve_user_id_from_token(websocket.query_params.get("token"))
+    current_session_id: Optional[int] = None
+
     try:
         await manager.connect(presentation_id, websocket)
         logger.info(f"[WebSocket Handshake] Connection accepted for {presentation_id}")
@@ -65,10 +74,33 @@ async def websocket_orchestration(websocket: WebSocket, presentation_id: str):
             logger.debug(f"Received WebSocket message for {presentation_id}: {data[:50]}...")
             try:
                 payload = json.loads(data)
+                message_type = payload.get("type")
+
+                if message_type == "SESSION_EVENT":
+                    event_name = payload.get("event")
+                    if event_name == "START" and current_session_id is None:
+                        current_slide = int(payload.get("current_page") or 1)
+                        current_session_id = await start_live_session(
+                            presentation_id=int(presentation_id),
+                            user_id=user_id,
+                            current_slide=current_slide,
+                        )
+                    elif event_name == "END" and current_session_id is not None:
+                        await end_live_session(current_session_id)
+                        current_session_id = None
+                    continue
+
                 transcript = payload.get("transcript", "")
                 is_final = payload.get("is_final", False)
                 current_slide = payload.get("current_page", 1)
                 total_slides = payload.get("total_pages", 1)
+
+                if current_session_id is None and (transcript or is_final):
+                    current_session_id = await start_live_session(
+                        presentation_id=int(presentation_id),
+                        user_id=user_id,
+                        current_slide=int(current_slide),
+                    )
                 
                 if is_final:
                     # Perform intent analysis with context
@@ -87,17 +119,15 @@ async def websocket_orchestration(websocket: WebSocket, presentation_id: str):
                     # Persist the current state to the latest active session (no await to keep responsive)
                     try:
                         async with AsyncSessionLocal() as db:
-                            # Update the most recent active session for this presentation
-                            # Note: presentation_id is a string from the URL, converting to int
-                            stmt = (
-                                update(PresentationSession)
-                                .where(PresentationSession.presentation_id == int(presentation_id))
-                                .where(PresentationSession.ended_at == None)
-                                .values(current_slide_index=current_slide)
-                            )
-                            await db.execute(stmt)
-                            await db.commit()
-                            logger.debug(f"Persisted slide state {current_slide} for presentation {presentation_id}")
+                            if current_session_id is not None:
+                                stmt = (
+                                    update(PresentationSession)
+                                    .where(PresentationSession.id == current_session_id)
+                                    .values(current_slide_index=current_slide)
+                                )
+                                await db.execute(stmt)
+                                await db.commit()
+                                logger.debug(f"Persisted slide state {current_slide} for presentation {presentation_id}")
                     except Exception as db_err:
                         logger.error(f"Database session update failed for {presentation_id}: {db_err}")
                 
@@ -116,6 +146,10 @@ async def websocket_orchestration(websocket: WebSocket, presentation_id: str):
                 
     except WebSocketDisconnect:
         manager.disconnect(presentation_id, websocket)
+        if current_session_id is not None:
+            await end_live_session(current_session_id)
     except Exception as e:
         logger.error(f"WebSocket error: {str(e)}")
         manager.disconnect(presentation_id, websocket)
+        if current_session_id is not None:
+            await end_live_session(current_session_id)

--- a/backend/app/api/v1/presentations.py
+++ b/backend/app/api/v1/presentations.py
@@ -17,7 +17,7 @@ MAX_FILE_SIZE = 50 * 1024 * 1024
 
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
-from app.models.presentation import Presentation
+from app.models.presentation import Presentation, PresentationSession
 
 
 class PresentationTitleUpdate(BaseModel):
@@ -49,6 +49,68 @@ async def list_presentations(
         }
         for p in presentations
     ]
+
+
+@router.get("/sessions/recent", response_model=list)
+async def list_recent_sessions(
+    limit: int = Query(100, ge=1, le=500),
+    db: AsyncSession = Depends(get_db),
+    current_user=Depends(auth.get_current_user),
+):
+    stmt = (
+        select(PresentationSession, Presentation)
+        .join(Presentation, Presentation.id == PresentationSession.presentation_id)
+        .where(PresentationSession.user_id == current_user.id)
+        .order_by(PresentationSession.started_at.desc())
+        .limit(limit)
+    )
+    result = await db.execute(stmt)
+    rows = result.all()
+
+    response = []
+    for session, presentation in rows:
+        duration_seconds = int(session.duration_seconds or 0)
+        duration_minutes = int(duration_seconds // 60)
+        response.append(
+            {
+                "id": session.id,
+                "session_type": session.session_type.value if hasattr(session.session_type, "value") else str(session.session_type),
+                "duration_seconds": duration_seconds,
+                "duration_minutes": duration_minutes,
+                "started_at": session.started_at.isoformat() if session.started_at else None,
+                "ended_at": session.ended_at.isoformat() if session.ended_at else None,
+                "presentation": {
+                    "id": presentation.id,
+                    "title": presentation.title,
+                    "slide_count": presentation.slide_count,
+                },
+            }
+        )
+
+    return response
+
+
+@router.delete("/sessions/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_session(
+    session_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user=Depends(auth.get_current_user),
+):
+    stmt = (
+        select(PresentationSession)
+        .join(Presentation, Presentation.id == PresentationSession.presentation_id)
+        .where(PresentationSession.id == session_id)
+        .where(Presentation.user_id == current_user.id)
+    )
+    result = await db.execute(stmt)
+    session = result.scalar_one_or_none()
+
+    if session is None:
+        raise ValidationError("Session not found")
+
+    await db.delete(session)
+    await db.commit()
+    return None
 
 @router.get("/{presentation_id}")
 async def get_presentation(

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -17,7 +17,7 @@ class Settings(BaseSettings):
         description="Secret key for JWT token signing. MUST be changed in production!"
     )
     ALGORITHM: str = "HS256"
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 120
 
     # Password reset configuration
     PASSWORD_RESET_TOKEN_EXPIRE_MINUTES: int = 60

--- a/backend/app/services/session_records_service.py
+++ b/backend/app/services/session_records_service.py
@@ -1,0 +1,75 @@
+from datetime import datetime, timezone
+from typing import Optional
+from uuid import uuid4
+
+from jose import JWTError, jwt
+from sqlalchemy import select
+
+from app.core.config import settings
+from app.core.database import AsyncSessionLocal
+from app.core.logger import logger
+from app.models.presentation import PresentationSession, SessionType, User
+
+
+async def resolve_user_id_from_token(token: Optional[str]) -> Optional[int]:
+    if not token:
+        return None
+
+    try:
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+        user_id = payload.get("sub")
+        if user_id is None:
+            return None
+        parsed_user_id = int(user_id)
+    except (JWTError, ValueError, TypeError):
+        return None
+
+    async with AsyncSessionLocal() as db:
+        result = await db.execute(select(User.id).where(User.id == parsed_user_id))
+        existing_id = result.scalar_one_or_none()
+        return existing_id
+
+
+async def start_live_session(
+    presentation_id: int,
+    user_id: Optional[int],
+    current_slide: int = 1,
+) -> Optional[int]:
+    try:
+        async with AsyncSessionLocal() as db:
+            session = PresentationSession(
+                user_id=user_id,
+                session_uuid=str(uuid4()),
+                presentation_id=presentation_id,
+                session_type=SessionType.LIVE,
+                current_slide_index=current_slide,
+            )
+            db.add(session)
+            await db.commit()
+            await db.refresh(session)
+            return session.id
+    except Exception as exc:
+        logger.error(f"Failed to start live session for presentation {presentation_id}: {exc}")
+        return None
+
+
+async def end_live_session(session_id: int) -> None:
+    ended_at = datetime.now(timezone.utc)
+    try:
+        async with AsyncSessionLocal() as db:
+            result = await db.execute(select(PresentationSession).where(PresentationSession.id == session_id))
+            session = result.scalar_one_or_none()
+            if session is None or session.ended_at is not None:
+                return
+
+            session.ended_at = ended_at
+            start_time = session.started_at
+            if start_time is not None:
+                if start_time.tzinfo is None:
+                    start_time = start_time.replace(tzinfo=timezone.utc)
+                duration_seconds = int((ended_at - start_time).total_seconds())
+                session.duration_seconds = max(0, duration_seconds)
+
+            await db.commit()
+    except Exception as exc:
+        logger.error(f"Failed to end live session {session_id}: {exc}")

--- a/frontend/app/analyze/page.tsx
+++ b/frontend/app/analyze/page.tsx
@@ -51,6 +51,8 @@ export default function AnalyzePage() {
     const chatEndRef = useRef<HTMLDivElement>(null);
     const searchParams = useSearchParams();
     const presentationId = searchParams.get('id');
+    const returnToParam = searchParams.get('returnTo');
+    const backHref = returnToParam && returnToParam.startsWith('/') ? returnToParam : '/dashboard';
 
     const [showChat, setShowChat] = useState(true);
     const [isCheckingAuth, setIsCheckingAuth] = useState(true);
@@ -253,7 +255,7 @@ export default function AnalyzePage() {
                         <div className="flex items-center gap-4">
                             {!isFullScreen && (
                                 <>
-                                    <Link href="/dashboard" className="p-2 hover:bg-white/5 rounded-full transition-colors text-zinc-400 hover:text-white">
+                                    <Link href={backHref} className="p-2 hover:bg-white/5 rounded-full transition-colors text-zinc-400 hover:text-white">
                                         <ArrowLeft size={20} />
                                     </Link>
                                     <div className="h-4 w-[1px] bg-white/10" />

--- a/frontend/app/dashboard/DashboardContext.tsx
+++ b/frontend/app/dashboard/DashboardContext.tsx
@@ -33,6 +33,7 @@ export interface RecentPresentation {
 export interface RecentSession {
     id: number;
     session_type: string;
+    duration_seconds: number;
     duration_minutes: number;
     started_at: string;
     ended_at: string | null;
@@ -62,6 +63,7 @@ interface DashboardContextType {
     alert: { type: 'info' | 'error', message: string } | null;
     setStats: React.Dispatch<React.SetStateAction<DashboardStats | null>>;
     setRecentPresentations: React.Dispatch<React.SetStateAction<RecentPresentation[]>>;
+    setRecentSessions: React.Dispatch<React.SetStateAction<RecentSession[]>>;
     setPresentations: React.Dispatch<React.SetStateAction<RecentPresentation[]>>;
 }
 
@@ -96,23 +98,33 @@ export function DashboardProvider({ children }: { children: React.ReactNode }) {
         }
 
         try {
-            const [userRes, allRes] = await Promise.all([
+            const [userRes, allRes, sessionsRes] = await Promise.all([
                 client.get("/api/v1/auth/me"),
-                client.get("/api/v1/presentations/")
+                client.get("/api/v1/presentations/"),
+                client.get("/api/v1/presentations/sessions/recent")
             ]);
 
             const allPresentations = allRes.data || [];
+            const allSessions: RecentSession[] = sessionsRes.data || [];
+            const totalDurationSeconds = allSessions.reduce((acc, session) => acc + (session.duration_seconds || 0), 0);
+            const liveDurationSeconds = allSessions
+                .filter((session) => session.session_type === 'live')
+                .reduce((acc, session) => acc + (session.duration_seconds || 0), 0);
+            const rehearsalDurationSeconds = allSessions
+                .filter((session) => session.session_type === 'rehearsal')
+                .reduce((acc, session) => acc + (session.duration_seconds || 0), 0);
+
             setUser(userRes.data);
             setPresentations(allPresentations);
             setRecentPresentations(allPresentations.slice(0, 5));
             setStats({
                 total_presentations: allPresentations.length,
-                total_rehearsal_hours: 0,
-                total_live_hours: 0,
-                total_sessions: 0,
-                avg_session_minutes: 0
+                total_rehearsal_hours: Number((rehearsalDurationSeconds / 3600).toFixed(1)),
+                total_live_hours: Number((liveDurationSeconds / 3600).toFixed(1)),
+                total_sessions: allSessions.length,
+                avg_session_minutes: allSessions.length > 0 ? Number(((totalDurationSeconds / 60) / allSessions.length).toFixed(1)) : 0,
             });
-            setRecentSessions([]);
+            setRecentSessions(allSessions);
         } catch (error) {
             console.error("Failed to fetch dashboard data:", error);
             localStorage.removeItem("access_token");
@@ -136,7 +148,7 @@ export function DashboardProvider({ children }: { children: React.ReactNode }) {
             user, stats, recentPresentations, recentSessions, presentations,
             loading, activeTab, setActiveTab, sidebarOpen, setSidebarOpen,
             searchQuery, setSearchQuery, handleLogout, refreshData: fetchDashboardData,
-            alert, setAlert, setStats, setRecentPresentations, setPresentations
+            alert, setAlert, setStats, setRecentPresentations, setRecentSessions, setPresentations
         }}>
             {children}
         </DashboardContext.Provider>

--- a/frontend/app/dashboard/library/Library.tsx
+++ b/frontend/app/dashboard/library/Library.tsx
@@ -146,7 +146,7 @@ export default function Library({ presentations, searchQuery, onDelete, setAlert
             closePlannerModal();
         } catch {
             setAlert({ type: 'error', message: 'Presentation could not be added to planner.' });
-            setTimeout(() => setAlert(null), 4500);
+            setTimeout(() => setAlert(null), 3500);
         }
     };
 

--- a/frontend/app/dashboard/library/Library.tsx
+++ b/frontend/app/dashboard/library/Library.tsx
@@ -401,7 +401,7 @@ function PresentationCard({
             </button>
 
             <div className="mt-auto grid grid-cols-2 gap-2">
-                <Link href={`/analyze?id=${presentation.id}`} className="flex-1">
+                <Link href={`/analyze?id=${presentation.id}&returnTo=${encodeURIComponent('/dashboard?tab=presentations')}`} className="flex-1">
                     <button className="flex w-full items-center justify-center gap-2 rounded-lg border border-white/10 bg-white/[0.03] px-3 py-2.5 text-xs font-bold text-zinc-200 transition-colors hover:bg-white/[0.08] hover:text-white">
                         View
                         <Eye size={14} />

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -870,7 +870,7 @@ function PresentationRow({ presentation, index, onDelete }: { presentation: Rece
                 </div>
             </div>
             <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
-                <Link href={`/analyze?id=${presentation.id}`}>
+                <Link href={`/analyze?id=${presentation.id}&returnTo=${encodeURIComponent('/dashboard?tab=overview')}`}>
                     <button className="p-2 rounded-lg bg-zinc-900 border border-white/5 text-zinc-400 hover:text-white transition-all hover:shadow-lg">
                         <Eye size={16} />
                     </button>
@@ -995,7 +995,7 @@ function PresentationCard({
                         <CalendarDays size={12} />
                         Add To Planner
                     </button>
-                    <Link href={`/analyze?id=${presentation.id}`}>
+                    <Link href={`/analyze?id=${presentation.id}&returnTo=${encodeURIComponent('/dashboard?tab=presentations')}`}>
                         <button className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-white/10 bg-white/[0.03] px-2.5 py-1.5 text-[11px] font-bold text-zinc-200 transition-colors hover:bg-white/[0.08] hover:text-white">
                             View
                             <Eye size={12} />

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
+import { createPortal } from "react-dom";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
     Presentation,
@@ -17,6 +18,7 @@ import {
     Eye,
     ArrowUpRight,
     ChevronDown,
+    MoreVertical,
     X,
 } from "lucide-react";
 import { motion } from "framer-motion";
@@ -914,6 +916,33 @@ function PresentationCard({
     const createdAt = new Date(presentation.created_at);
     const createdDate = `${String(createdAt.getDate()).padStart(2, '0')}/${String(createdAt.getMonth() + 1).padStart(2, '0')}/${createdAt.getFullYear()}`;
     const isEditing = editingPresentationId === presentation.id;
+    const [isActionMenuOpen, setIsActionMenuOpen] = useState(false);
+    const [actionMenuPosition, setActionMenuPosition] = useState<{ top: number; left: number } | null>(null);
+
+    useEffect(() => {
+        if (!isActionMenuOpen) return;
+
+        const closeMenu = () => {
+            setIsActionMenuOpen(false);
+            setActionMenuPosition(null);
+        };
+
+        const handleOutsideClick = (event: MouseEvent) => {
+            const target = event.target as Element | null;
+            if (target?.closest('[data-presentation-menu-root]')) return;
+            closeMenu();
+        };
+
+        document.addEventListener('mousedown', handleOutsideClick);
+        window.addEventListener('resize', closeMenu);
+        window.addEventListener('scroll', closeMenu, true);
+
+        return () => {
+            document.removeEventListener('mousedown', handleOutsideClick);
+            window.removeEventListener('resize', closeMenu);
+            window.removeEventListener('scroll', closeMenu, true);
+        };
+    }, [isActionMenuOpen]);
 
     return (
         <motion.tr
@@ -986,34 +1015,93 @@ function PresentationCard({
             </td>
 
             <td className="px-8 py-5 text-right">
-                <div className="flex flex-wrap items-center justify-end gap-2">
+                <div className="inline-flex" data-presentation-menu-root>
                     <button
                         type="button"
-                        onClick={() => onAddToPlanner(presentation)}
-                        className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-primary/35 bg-primary/10 px-2.5 py-1.5 text-[11px] font-bold text-primary transition-colors hover:bg-primary/20"
+                        onClick={(event) => {
+                            if (isActionMenuOpen) {
+                                setIsActionMenuOpen(false);
+                                setActionMenuPosition(null);
+                                return;
+                            }
+
+                            const rect = event.currentTarget.getBoundingClientRect();
+                            const menuWidth = 192;
+                            const margin = 8;
+                            const left = Math.min(
+                                window.innerWidth - menuWidth - margin,
+                                Math.max(margin, rect.right - menuWidth)
+                            );
+
+                            setActionMenuPosition({ top: rect.bottom + 6, left });
+                            setIsActionMenuOpen(true);
+                        }}
+                        className="rounded-lg p-2 text-zinc-500 transition-all hover:bg-white/5 hover:text-white"
+                        title="Presentation actions"
+                        aria-label="Presentation actions"
                     >
-                        <CalendarDays size={12} />
-                        Add To Planner
+                        <MoreVertical size={16} />
                     </button>
-                    <Link href={`/analyze?id=${presentation.id}&returnTo=${encodeURIComponent('/dashboard?tab=presentations')}`}>
-                        <button className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-white/10 bg-white/[0.03] px-2.5 py-1.5 text-[11px] font-bold text-zinc-200 transition-colors hover:bg-white/[0.08] hover:text-white">
-                            View
-                            <Eye size={12} />
-                        </button>
-                    </Link>
-                    <Link href={`/presentation/${presentation.id}`}>
-                        <button className="inline-flex items-center justify-center gap-1.5 rounded-lg bg-primary px-2.5 py-1.5 text-[11px] font-bold text-white transition-colors hover:bg-primary-hover active:scale-95">
-                            Start
-                            <Play size={12} className="fill-white" />
-                        </button>
-                    </Link>
-                    <button
-                        onClick={() => onDelete(presentation.id)}
-                        className="inline-flex items-center justify-center rounded-lg border border-white/10 bg-zinc-900 p-1.5 text-zinc-500 transition-colors hover:border-red-500/40 hover:text-red-400"
-                        title="Delete presentation"
-                    >
-                        <Trash2 size={14} />
-                    </button>
+
+                    {isActionMenuOpen && actionMenuPosition && typeof document !== 'undefined' &&
+                        createPortal(
+                            <div
+                                data-presentation-menu-root
+                                className="fixed z-[120] w-48 overflow-hidden rounded-xl border border-white/10 bg-[#111111] shadow-xl"
+                                style={{ top: actionMenuPosition.top, left: actionMenuPosition.left }}
+                            >
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                        setIsActionMenuOpen(false);
+                                        setActionMenuPosition(null);
+                                        onAddToPlanner(presentation);
+                                    }}
+                                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-zinc-200 transition-colors hover:bg-primary/15 hover:text-primary"
+                                >
+                                    <CalendarDays size={14} />
+                                    Add to planner
+                                </button>
+
+                                <Link
+                                    href={`/analyze?id=${presentation.id}&returnTo=${encodeURIComponent('/dashboard?tab=presentations')}`}
+                                    onClick={() => {
+                                        setIsActionMenuOpen(false);
+                                        setActionMenuPosition(null);
+                                    }}
+                                    className="flex w-full items-center gap-2 px-3 py-2 text-sm text-zinc-200 transition-colors hover:bg-white/5 hover:text-white"
+                                >
+                                    <Eye size={14} />
+                                    View
+                                </Link>
+
+                                <Link
+                                    href={`/presentation/${presentation.id}`}
+                                    onClick={() => {
+                                        setIsActionMenuOpen(false);
+                                        setActionMenuPosition(null);
+                                    }}
+                                    className="flex w-full items-center gap-2 px-3 py-2 text-sm text-zinc-200 transition-colors hover:bg-white/5 hover:text-white"
+                                >
+                                    <Play size={14} />
+                                    Present again
+                                </Link>
+
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                        setIsActionMenuOpen(false);
+                                        setActionMenuPosition(null);
+                                        onDelete(presentation.id);
+                                    }}
+                                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-zinc-200 transition-colors hover:bg-red-500/10 hover:text-red-400"
+                                >
+                                    <Trash2 size={14} />
+                                    Delete
+                                </button>
+                            </div>,
+                            document.body
+                        )}
                 </div>
             </td>
         </motion.tr>

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -98,8 +98,50 @@ export default function DashboardPage() {
         alert,
         setRecentPresentations,
         setPresentations,
+        setRecentSessions,
         setActiveTab
     } = useDashboard();
+
+    const handleDeleteSession = async (sessionId: number) => {
+        if (!confirm("Are you sure you want to delete this session record?")) return;
+
+        try {
+            await client.delete(`/api/v1/presentations/sessions/${sessionId}`);
+            setRecentSessions((prev) => {
+                const removed = prev.find((session) => session.id === sessionId);
+                const next = prev.filter((session) => session.id !== sessionId);
+
+                if (removed && stats) {
+                    const removedMinutes = (removed.duration_seconds || 0) / 60;
+                    const nextCount = Math.max(0, stats.total_sessions - 1);
+                    const currentTotalMinutes = (stats.avg_session_minutes || 0) * (stats.total_sessions || 0);
+                    const nextTotalMinutes = Math.max(0, currentTotalMinutes - removedMinutes);
+
+                    const nextLiveHours = removed.session_type === 'live'
+                        ? Math.max(0, (stats.total_live_hours || 0) - removedMinutes / 60)
+                        : (stats.total_live_hours || 0);
+                    const nextRehearsalHours = removed.session_type === 'rehearsal'
+                        ? Math.max(0, (stats.total_rehearsal_hours || 0) - removedMinutes / 60)
+                        : (stats.total_rehearsal_hours || 0);
+
+                    setStats({
+                        ...stats,
+                        total_sessions: nextCount,
+                        avg_session_minutes: nextCount > 0 ? Number((nextTotalMinutes / nextCount).toFixed(1)) : 0,
+                        total_live_hours: Number(nextLiveHours.toFixed(1)),
+                        total_rehearsal_hours: Number(nextRehearsalHours.toFixed(1)),
+                    });
+                }
+
+                return next;
+            });
+            setAlert({ type: 'info', message: 'Session deleted.' });
+            setTimeout(() => setAlert(null), 3000);
+        } catch {
+            setAlert({ type: 'error', message: 'Session could not be deleted.' });
+            setTimeout(() => setAlert(null), 4000);
+        }
+    };
 
     const [plannerModalPresentation, setPlannerModalPresentation] = useState<RecentPresentation | null>(null);
     const [plannerDate, setPlannerDate] = useState(() => toDateKey(new Date()));
@@ -447,7 +489,7 @@ export default function DashboardPage() {
 
             {/* Sessions Tab */}
             {activeTab === 'sessions' && (
-                <Sessions sessions={recentSessions} searchQuery={searchQuery} />
+                <Sessions sessions={recentSessions} searchQuery={searchQuery} onDeleteSession={handleDeleteSession} />
             )}
 
             {plannerModalPresentation && (

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -138,10 +138,10 @@ export default function DashboardPage() {
                 return next;
             });
             setAlert({ type: 'info', message: 'Session deleted.' });
-            setTimeout(() => setAlert(null), 3000);
+            setTimeout(() => setAlert(null), 3500);
         } catch {
             setAlert({ type: 'error', message: 'Session could not be deleted.' });
-            setTimeout(() => setAlert(null), 4000);
+            setTimeout(() => setAlert(null), 3500);
         }
     };
 
@@ -191,7 +191,7 @@ export default function DashboardPage() {
             }
 
             setAlert({ type: 'error', message: msg });
-            setTimeout(() => setAlert(null), 4500);
+            setTimeout(() => setAlert(null), 3500);
         }
     };
 
@@ -236,11 +236,11 @@ export default function DashboardPage() {
             );
 
             setAlert({ type: 'info', message: 'Presentation title updated.' });
-            setTimeout(() => setAlert(null), 3000);
+            setTimeout(() => setAlert(null), 3500);
             cancelEditingPresentationTitle();
         } catch {
             setAlert({ type: 'error', message: 'Presentation title could not be updated.' });
-            setTimeout(() => setAlert(null), 4000);
+            setTimeout(() => setAlert(null), 3500);
             setIsSavingPresentationTitle(false);
         }
     };
@@ -314,7 +314,7 @@ export default function DashboardPage() {
             closePlannerModal();
         } catch {
             setAlert({ type: 'error', message: 'Presentation could not be added to planner.' });
-            setTimeout(() => setAlert(null), 4500);
+            setTimeout(() => setAlert(null), 3500);
         }
     };
 

--- a/frontend/app/dashboard/planner/PlannerCalendar.tsx
+++ b/frontend/app/dashboard/planner/PlannerCalendar.tsx
@@ -219,7 +219,7 @@ export default function PlannerCalendar() {
         return new Date(n.getFullYear(), n.getMonth(), 1);
     });
     const [weekStart, setWeekStart] = useState(() => startOfWeekMonday(new Date()));
-    const [selected, setSelected] = useState<Date | null>(null);
+    const [selected, setSelected] = useState<Date | null>(() => startOfDay(new Date()));
     const { presentations, setAlert } = useDashboard();
 
     // Scheduling State
@@ -707,17 +707,14 @@ export default function PlannerCalendar() {
                                                     ${isSelected(day)
                                                         ? 'z-[1] border-2 border-primary bg-primary/20 text-primary shadow-[0_0_20px_-4px_rgba(234,88,12,0.45)]'
                                                         : 'border border-transparent text-zinc-300 hover:border-white/10 hover:bg-white/[0.06]'}
-                                                    ${isToday(day) && !isSelected(day)
-                                                        ? 'bg-primary/5 text-white ring-1 ring-primary/50'
-                                                        : ''}
                                                 `}
                                             >
-                                                <span className="absolute left-2 top-2 text-xs font-semibold sm:text-sm">
-                                                    {day}
+                                                <span className="absolute left-2 top-2 inline-flex items-center gap-1 text-xs font-semibold sm:text-sm">
+                                                    <span>{day}</span>
+                                                    {isToday(day) && (
+                                                        <span className="h-1.5 w-1.5 rounded-full bg-primary shadow-[0_0_8px_rgba(234,88,12,0.8)]" aria-hidden="true" />
+                                                    )}
                                                 </span>
-                                                {isToday(day) && (
-                                                    <span className="absolute bottom-1.5 left-1/2 h-1 w-1 -translate-x-1/2 rounded-full bg-primary sm:bottom-2" />
-                                                )}
 
                                                 <div className="absolute inset-x-1 top-7 bottom-1 overflow-hidden pointer-events-none hidden sm:flex flex-col gap-1">
                                                     {(events[toDateKey(new Date(viewYear, viewMonth, day))] || []).slice(0, 2).map(ev => (
@@ -782,17 +779,14 @@ export default function PlannerCalendar() {
                                                     ${sel
                                                         ? 'z-[1] border-2 border-primary bg-primary/20 text-primary shadow-[0_0_20px_-4px_rgba(234,88,12,0.45)]'
                                                         : 'border border-transparent text-zinc-300 hover:border-white/10 hover:bg-white/[0.06]'}
-                                                    ${today && !sel
-                                                        ? 'bg-primary/5 text-white ring-1 ring-primary/50'
-                                                        : ''}
                                                 `}
                                             >
-                                                <span className="absolute left-2 top-2 text-xs font-semibold sm:text-sm">
-                                                    {d.getDate()}
+                                                <span className="absolute left-2 top-2 inline-flex items-center gap-1 text-xs font-semibold sm:text-sm">
+                                                    <span>{d.getDate()}</span>
+                                                    {today && (
+                                                        <span className="h-1.5 w-1.5 rounded-full bg-primary shadow-[0_0_8px_rgba(234,88,12,0.8)]" aria-hidden="true" />
+                                                    )}
                                                 </span>
-                                                {today && (
-                                                    <span className="absolute bottom-1.5 left-1/2 h-1 w-1 -translate-x-1/2 rounded-full bg-primary sm:bottom-2" />
-                                                )}
 
                                                 <div className="absolute inset-x-1 top-7 bottom-1 overflow-hidden pointer-events-none hidden sm:flex flex-col gap-1">
                                                     {(events[toDateKey(d)] || []).slice(0, 2).map(ev => (

--- a/frontend/app/dashboard/planner/PlannerCalendar.tsx
+++ b/frontend/app/dashboard/planner/PlannerCalendar.tsx
@@ -407,6 +407,7 @@ export default function PlannerCalendar() {
             setEvents(grouped);
         } catch {
             setAlert({ type: 'error', message: 'Planner events could not be loaded.' });
+            setTimeout(() => setAlert(null), 3500);
         }
     }, [setAlert, toScheduledEvent]);
 
@@ -467,8 +468,10 @@ export default function PlannerCalendar() {
             setEditingEventId(null);
             setEditingDateKey(null);
             setAlert({ type: 'info', message: editingEventId ? 'Event updated.' : 'Event saved to planner.' });
+            setTimeout(() => setAlert(null), 3500);
         } catch {
             setAlert({ type: 'error', message: editingEventId ? 'Event could not be updated.' : 'Event could not be saved.' });
+            setTimeout(() => setAlert(null), 3500);
         }
     };
 
@@ -484,8 +487,10 @@ export default function PlannerCalendar() {
                 ),
             }));
             setAlert({ type: 'info', message: 'Reminder removed.' });
+            setTimeout(() => setAlert(null), 3500);
         } catch {
             setAlert({ type: 'error', message: 'Reminder could not be removed.' });
+            setTimeout(() => setAlert(null), 3500);
         }
     };
 
@@ -505,8 +510,10 @@ export default function PlannerCalendar() {
                 };
             });
             setAlert({ type: 'info', message: 'Scheduled presentation removed.' });
+            setTimeout(() => setAlert(null), 3500);
         } catch {
             setAlert({ type: 'error', message: 'Scheduled presentation could not be removed.' });
+            setTimeout(() => setAlert(null), 3500);
         }
     };
 

--- a/frontend/app/dashboard/sessions/Sessions.tsx
+++ b/frontend/app/dashboard/sessions/Sessions.tsx
@@ -191,7 +191,7 @@ export default function Sessions({ sessions, searchQuery, onDeleteSession }: Ses
                                     className="flex w-full items-center gap-2 px-3 py-2 text-sm text-zinc-200 transition-colors hover:bg-white/5 hover:text-white"
                                 >
                                     <Play size={14} />
-                                    Present again
+                                    New session
                                 </Link>
 
                                 <Link

--- a/frontend/app/dashboard/sessions/Sessions.tsx
+++ b/frontend/app/dashboard/sessions/Sessions.tsx
@@ -1,16 +1,17 @@
 'use client';
 
 import React, { useMemo } from 'react';
-import { Eye } from 'lucide-react';
+import { Eye, Trash2 } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { RecentSession } from '../DashboardContext';
 
 interface SessionsProps {
     sessions: RecentSession[];
     searchQuery: string;
+    onDeleteSession: (sessionId: number) => void;
 }
 
-export default function Sessions({ sessions, searchQuery }: SessionsProps) {
+export default function Sessions({ sessions, searchQuery, onDeleteSession }: SessionsProps) {
     const filteredSessions = useMemo(() => {
         const query = searchQuery.trim().toLowerCase();
         if (!query) return sessions;
@@ -18,6 +19,15 @@ export default function Sessions({ sessions, searchQuery }: SessionsProps) {
             session.presentation.title?.toLowerCase().includes(query)
         );
     }, [sessions, searchQuery]);
+
+    const formatDuration = (durationSeconds?: number, fallbackMinutes?: number) => {
+        const total = Number.isFinite(durationSeconds as number)
+            ? Math.max(0, Math.floor(durationSeconds as number))
+            : Math.max(0, Math.floor((fallbackMinutes || 0) * 60));
+        const minutes = Math.floor(total / 60);
+        const seconds = total % 60;
+        return `${minutes}:${String(seconds).padStart(2, '0')}`;
+    };
 
     return (
         <motion.div
@@ -60,14 +70,26 @@ export default function Sessions({ sessions, searchQuery }: SessionsProps) {
                                                 {s.session_type === 'rehearsal' ? 'Rehearsal' : 'Live'}
                                             </span>
                                         </td>
-                                        <td className="px-8 py-5 text-sm text-zinc-400">{s.duration_minutes} min</td>
+                                        <td className="px-8 py-5 text-sm text-zinc-400">
+                                            {formatDuration(s.duration_seconds, s.duration_minutes)}
+                                        </td>
                                         <td className="px-8 py-5 text-sm text-zinc-400">
                                             {new Date(s.started_at).toLocaleDateString('en-GB')}
                                         </td>
                                         <td className="px-8 py-5 text-right">
-                                            <button className="rounded-lg p-2 text-zinc-500 transition-all hover:bg-white/5 hover:text-white">
-                                                <Eye size={16} />
-                                            </button>
+                                            <div className="inline-flex items-center gap-1">
+                                                <button className="rounded-lg p-2 text-zinc-500 transition-all hover:bg-white/5 hover:text-white">
+                                                    <Eye size={16} />
+                                                </button>
+                                                <button
+                                                    onClick={() => onDeleteSession(s.id)}
+                                                    className="rounded-lg p-2 text-zinc-500 transition-all hover:bg-red-500/10 hover:text-red-400"
+                                                    title="Delete session"
+                                                    aria-label="Delete session"
+                                                >
+                                                    <Trash2 size={16} />
+                                                </button>
+                                            </div>
                                         </td>
                                     </tr>
                                 ))}

--- a/frontend/app/dashboard/sessions/Sessions.tsx
+++ b/frontend/app/dashboard/sessions/Sessions.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import React, { useMemo } from 'react';
-import { Eye, Trash2 } from 'lucide-react';
+import React, { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { Eye, MoreVertical, Play, Trash2 } from 'lucide-react';
 import { motion } from 'framer-motion';
+import { createPortal } from 'react-dom';
 import { RecentSession } from '../DashboardContext';
 
 interface SessionsProps {
@@ -12,6 +14,9 @@ interface SessionsProps {
 }
 
 export default function Sessions({ sessions, searchQuery, onDeleteSession }: SessionsProps) {
+    const [openMenuId, setOpenMenuId] = useState<number | null>(null);
+    const [menuPosition, setMenuPosition] = useState<{ top: number; left: number } | null>(null);
+
     const filteredSessions = useMemo(() => {
         const query = searchQuery.trim().toLowerCase();
         if (!query) return sessions;
@@ -19,6 +24,37 @@ export default function Sessions({ sessions, searchQuery, onDeleteSession }: Ses
             session.presentation.title?.toLowerCase().includes(query)
         );
     }, [sessions, searchQuery]);
+
+    const openMenuSession = useMemo(
+        () => filteredSessions.find((session) => session.id === openMenuId) ?? null,
+        [filteredSessions, openMenuId]
+    );
+
+    useEffect(() => {
+        const handleOutsideClick = (event: MouseEvent) => {
+            const target = event.target as Element | null;
+            if (target?.closest('[data-session-menu-root]')) return;
+            setOpenMenuId(null);
+            setMenuPosition(null);
+        };
+
+        document.addEventListener('mousedown', handleOutsideClick);
+        return () => document.removeEventListener('mousedown', handleOutsideClick);
+    }, []);
+
+    useEffect(() => {
+        const closeMenu = () => {
+            setOpenMenuId(null);
+            setMenuPosition(null);
+        };
+
+        window.addEventListener('resize', closeMenu);
+        window.addEventListener('scroll', closeMenu, true);
+        return () => {
+            window.removeEventListener('resize', closeMenu);
+            window.removeEventListener('scroll', closeMenu, true);
+        };
+    }, []);
 
     const formatDuration = (durationSeconds?: number, fallbackMinutes?: number) => {
         const total = Number.isFinite(durationSeconds as number)
@@ -42,13 +78,14 @@ export default function Sessions({ sessions, searchQuery, onDeleteSession }: Ses
 
                 <div className="bg-[#0C0C0C] border border-white/5 rounded-[2rem] overflow-hidden">
                     <div className="overflow-x-auto">
-                        <table className="min-w-[760px] w-full text-left">
+                        <table className="min-w-[860px] w-full text-left">
                             <thead>
                                 <tr className="border-b border-white/5">
                                     <th className="px-8 py-6 text-xs font-bold text-zinc-500 uppercase tracking-widest">Presentation</th>
                                     <th className="px-8 py-6 text-xs font-bold text-zinc-500 uppercase tracking-widest">Type</th>
                                     <th className="px-8 py-6 text-xs font-bold text-zinc-500 uppercase tracking-widest">Duration</th>
                                     <th className="px-8 py-6 text-xs font-bold text-zinc-500 uppercase tracking-widest">Date</th>
+                                    <th className="px-8 py-6 text-xs font-bold text-zinc-500 uppercase tracking-widest">Time</th>
                                     <th className="px-8 py-6 text-xs font-bold text-zinc-500 uppercase tracking-widest text-right">Action</th>
                                 </tr>
                             </thead>
@@ -76,18 +113,42 @@ export default function Sessions({ sessions, searchQuery, onDeleteSession }: Ses
                                         <td className="px-8 py-5 text-sm text-zinc-400">
                                             {new Date(s.started_at).toLocaleDateString('en-GB')}
                                         </td>
+                                        <td className="px-8 py-5 text-sm text-zinc-400">
+                                            {new Date(s.started_at).toLocaleTimeString('en-GB', {
+                                                hour: '2-digit',
+                                                minute: '2-digit',
+                                                hour12: false,
+                                            })}
+                                        </td>
                                         <td className="px-8 py-5 text-right">
-                                            <div className="inline-flex items-center gap-1">
-                                                <button className="rounded-lg p-2 text-zinc-500 transition-all hover:bg-white/5 hover:text-white">
-                                                    <Eye size={16} />
-                                                </button>
+                                            <div className="inline-flex" data-session-menu-root>
                                                 <button
-                                                    onClick={() => onDeleteSession(s.id)}
-                                                    className="rounded-lg p-2 text-zinc-500 transition-all hover:bg-red-500/10 hover:text-red-400"
-                                                    title="Delete session"
-                                                    aria-label="Delete session"
+                                                    type="button"
+                                                    onClick={(event) => {
+                                                        if (openMenuId === s.id) {
+                                                            setOpenMenuId(null);
+                                                            setMenuPosition(null);
+                                                            return;
+                                                        }
+
+                                                        const rect = event.currentTarget.getBoundingClientRect();
+                                                        const menuWidth = 176;
+                                                        const margin = 8;
+                                                        const left = Math.min(
+                                                            window.innerWidth - menuWidth - margin,
+                                                            Math.max(margin, rect.right - menuWidth)
+                                                        );
+                                                        setMenuPosition({
+                                                            top: rect.bottom + 6,
+                                                            left,
+                                                        });
+                                                        setOpenMenuId(s.id);
+                                                    }}
+                                                    className="rounded-lg p-2 text-zinc-500 transition-all hover:bg-white/5 hover:text-white"
+                                                    title="Session actions"
+                                                    aria-label="Session actions"
                                                 >
-                                                    <Trash2 size={16} />
+                                                    <MoreVertical size={16} />
                                                 </button>
                                             </div>
                                         </td>
@@ -100,6 +161,53 @@ export default function Sessions({ sessions, searchQuery, onDeleteSession }: Ses
                     {filteredSessions.length === 0 && (
                         <div className="py-20 text-center text-zinc-600 italic">No recorded sessions found.</div>
                     )}
+
+                    {openMenuSession && menuPosition && typeof document !== 'undefined' &&
+                        createPortal(
+                            <div
+                                data-session-menu-root
+                                className="fixed z-[120] w-44 overflow-hidden rounded-xl border border-white/10 bg-[#111111] shadow-xl"
+                                style={{ top: menuPosition.top, left: menuPosition.left }}
+                            >
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                        setOpenMenuId(null);
+                                        setMenuPosition(null);
+                                        onDeleteSession(openMenuSession.id);
+                                    }}
+                                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-zinc-200 transition-colors hover:bg-red-500/10 hover:text-red-400"
+                                >
+                                    <Trash2 size={14} />
+                                    Delete
+                                </button>
+
+                                <Link
+                                    href={`/presentation/${openMenuSession.presentation.id}`}
+                                    onClick={() => {
+                                        setOpenMenuId(null);
+                                        setMenuPosition(null);
+                                    }}
+                                    className="flex w-full items-center gap-2 px-3 py-2 text-sm text-zinc-200 transition-colors hover:bg-white/5 hover:text-white"
+                                >
+                                    <Play size={14} />
+                                    Present again
+                                </Link>
+
+                                <Link
+                                    href={`/analyze?id=${openMenuSession.presentation.id}&returnTo=${encodeURIComponent('/dashboard?tab=sessions')}`}
+                                    onClick={() => {
+                                        setOpenMenuId(null);
+                                        setMenuPosition(null);
+                                    }}
+                                    className="flex w-full items-center gap-2 px-3 py-2 text-sm text-zinc-200 transition-colors hover:bg-white/5 hover:text-white"
+                                >
+                                    <Eye size={14} />
+                                    View
+                                </Link>
+                            </div>,
+                            document.body
+                        )}
                 </div>
             </div>
         </motion.div>

--- a/frontend/app/presentation/[id]/page.tsx
+++ b/frontend/app/presentation/[id]/page.tsx
@@ -109,6 +109,7 @@ export default function RealTimePresentationPage() {
     const viewerContainerRef = useRef<HTMLDivElement>(null);
     const currentPageRef = useRef(currentPage);
     const totalPagesRef = useRef(totalPages);
+    const isListeningRef = useRef(isListening);
 
     // Sync refs with state to avoid closure staleness in STT/WebSocket handlers
     useEffect(() => {
@@ -118,6 +119,21 @@ export default function RealTimePresentationPage() {
     useEffect(() => {
         totalPagesRef.current = totalPages;
     }, [totalPages]);
+
+    useEffect(() => {
+        isListeningRef.current = isListening;
+    }, [isListening]);
+
+    const sendSessionEvent = useCallback((eventName: "START" | "END") => {
+        if (socketRef.current?.readyState !== WebSocket.OPEN) return;
+        socketRef.current.send(JSON.stringify({
+            type: "SESSION_EVENT",
+            event: eventName,
+            session_type: "live",
+            current_page: currentPageRef.current,
+            total_pages: totalPagesRef.current,
+        }));
+    }, []);
 
     // Fetch presentation details
     useEffect(() => {
@@ -228,7 +244,10 @@ export default function RealTimePresentationPage() {
             const socketId = Math.random().toString(36).substring(7);
             const host = typeof window !== 'undefined' ? window.location.hostname : '127.0.0.1';
             const baseWsUrl = process.env.NEXT_PUBLIC_WS_URL || `ws://${host}:8000`;
-            const wsUrl = `${baseWsUrl}/api/v1/orchestration/ws/presentation/${presentationId}`;
+            const token = typeof window !== 'undefined' ? localStorage.getItem('access_token') : null;
+            const wsUrl = token
+                ? `${baseWsUrl}/api/v1/orchestration/ws/presentation/${presentationId}?token=${encodeURIComponent(token)}`
+                : `${baseWsUrl}/api/v1/orchestration/ws/presentation/${presentationId}`;
 
             console.log(`[WebSocket] [${socketId}] Connecting to: ${wsUrl} (Current Host: ${host})`);
             setWsStatus("connecting");
@@ -239,6 +258,9 @@ export default function RealTimePresentationPage() {
             socket.onopen = () => {
                 console.log(`[WebSocket] [${socketId}] Connected successfully`);
                 setWsStatus("connected");
+                if (isListeningRef.current) {
+                    sendSessionEvent("START");
+                }
             };
 
             socket.onmessage = (event) => {
@@ -282,7 +304,7 @@ export default function RealTimePresentationPage() {
             if (socket) socket.close();
             clearTimeout(reconnectTimeout);
         };
-    }, [presentationId, handleCommand]);
+    }, [presentationId, handleCommand, sendSessionEvent]);
 
     const toggleFullScreen = () => {
         if (!document.fullscreenElement && viewerContainerRef.current) {
@@ -322,6 +344,7 @@ export default function RealTimePresentationPage() {
             setIsListening(false);
         } else {
             setSttError(null);
+            sendSessionEvent("START");
             startSpeechRecognition();
         }
     };

--- a/frontend/app/upload/page.tsx
+++ b/frontend/app/upload/page.tsx
@@ -189,9 +189,9 @@ export default function UploadPage() {
         // Authenticated user - redirect to analyze page
         const presentationId = localStorage.getItem("last_presentation_id");
         if (presentationId) {
-            router.push(`/analyze?id=${presentationId}`);
+            router.push(`/analyze?id=${presentationId}&returnTo=${encodeURIComponent('/upload')}`);
         } else {
-            router.push("/analyze");
+            router.push(`/analyze?returnTo=${encodeURIComponent('/upload')}`);
         }
     };
 

--- a/reports/13Apr_dashboard-page-responsive-design(planner).md
+++ b/reports/13Apr_dashboard-page-responsive-design(planner).md
@@ -1,0 +1,129 @@
+# Changelog - April 13, 2026
+
+## Branch
+- **Name:** `51-dashboard-page-responsive-design`
+- **Base Comparison:** `main...HEAD`
+- **Scope:** Dashboard responsive redesign, Planner feature set, reminder email flow, and supporting backend/frontend updates.
+
+## Change Summary
+- **23 files changed**
+- **+3457 insertions / -191 deletions**
+- Major delivery areas:
+	- Planner domain model + API + reminder worker (backend)
+	- Responsive dashboard experience (frontend)
+	- Library page expansion with direct planning action
+	- Sessions/planner UX polishing
+	- Planner API test coverage
+
+## Backend Updates
+
+### 1. New Planner Domain Model
+- Added `PlannerEvent` model to `backend/app/models/presentation.py`.
+- Linked relationships:
+	- `User.planner_events`
+	- `Presentation.planner_events`
+- Added scheduling-related indexes for better query performance:
+	- `(user_id, scheduled_at)`
+	- `(presentation_id, scheduled_at)`
+- Added reminder tracking field `reminder_sent_at`.
+
+### 2. Planner API Endpoints
+- Added new router at `backend/app/api/v1/dashboard/planner/planner.py`.
+- Implemented endpoints:
+	- `POST /api/v1/planner/events` (create)
+	- `GET /api/v1/planner/events` (list, optional date filter)
+	- `PUT /api/v1/planner/events/{event_id}` (update)
+	- `DELETE /api/v1/planner/events/{event_id}` (delete event)
+	- `DELETE /api/v1/planner/events/{event_id}/reminder` (remove reminder only)
+- Event creation/update validates ownership of presentation and user.
+- Timezone value is accepted and persisted on user profile when provided.
+
+### 3. Planner Schemas
+- Added `backend/app/schemas/planner.py` with:
+	- `PlannerEventCreate`
+	- `PlannerEventResponse`
+- Added validation for:
+	- `HH:MM` 24-hour time format
+	- IANA timezone values (`zoneinfo` validation)
+
+### 4. Reminder Email Worker
+- Added `backend/app/services/planner_reminder_service.py`.
+- Implemented periodic worker (`POLL_INTERVAL_SECONDS = 60`) to:
+	- fetch due reminders (`reminder_at <= now` and not yet sent)
+	- send one email per due event
+	- mark `reminder_sent_at` after successful delivery
+- Worker is started/stopped via app lifespan in `backend/main.py`.
+
+### 5. Email Service Extension
+- Added `send_presentation_reminder_email(...)` in `backend/app/services/email_service.py`.
+- Reminder email now includes:
+	- presentation title
+	- scheduled date/time
+	- optional note
+
+### 6. Migration
+- Added migration script:
+	- `backend/scripts/migrations/2026_04_11_add_reminder_sent_at_to_planner_events.sql`
+- Introduced `reminder_sent_at TIMESTAMPTZ` + index.
+
+### 7. Additional Backend Improvements
+- Chat DTO cleanup:
+	- moved `ChatRequest` and `ChatResponse` from API module to `backend/app/schemas/chat.py`.
+- Presentation title editing support:
+	- added `PATCH /api/v1/presentations/{presentation_id}` in `backend/app/api/v1/presentations.py`.
+
+## Frontend Updates
+
+### 1. Dashboard Responsive Redesign
+- Significant responsive refactor in:
+	- `frontend/app/dashboard/page.tsx`
+	- `frontend/app/dashboard/layout.tsx`
+- Improved small-screen behavior for header/actions and content blocks.
+- Added stronger adaptive spacing and control sizing for mobile/tablet/desktop.
+
+### 2. Planner UI Delivery
+- Added planner route page: `frontend/app/dashboard/planner/page.tsx`.
+- Added full planner calendar implementation:
+	- `frontend/app/dashboard/planner/PlannerCalendar.tsx`
+- Implemented multi-view calendar modes:
+	- day / week / month
+- Event management from UI:
+	- add event
+	- edit event
+	- delete event
+	- remove reminder
+- Reminder UX enhancements:
+	- quick “30 minutes before” helper
+	- hour/minute pickers
+	- note step in creation flow
+
+### 3. Library Experience Expansion
+- Added large reusable library module:
+	- `frontend/app/dashboard/library/Library.tsx`
+- Added direct “Add to Planner” flow from library cards.
+- Added planner modal inputs:
+	- schedule date/time
+	- reminder options
+	- optional note
+- Added local-to-UTC conversion before API submission.
+
+### 4. Sessions & Styling
+- Added sessions module at `frontend/app/dashboard/sessions/Sessions.tsx`.
+- Updated global styles in `frontend/app/globals.css` to support new dashboard/planner visual behavior.
+- Minor landing page update in `frontend/app/page.tsx`.
+- Dependency lockfile updated: `frontend/package-lock.json`.
+
+## Test Coverage
+- Added planner API test file: `backend/tests/test_planner.py`.
+- Scenario covered:
+	- login
+	- create planner event
+	- list planner events by date
+	- delete planner event
+- Updated `backend/tests/conftest.py` dependency overrides for planner DB injection.
+
+## Functional Outcome
+- Users can now schedule presentations via dashboard planner.
+- Reminder emails are delivered automatically for due reminders.
+- Reminder delivery is tracked to avoid duplicate notifications.
+- Dashboard planner and related pages provide improved responsive behavior on different screen sizes.

--- a/reports/13Apr_dashboard-page-responsive-design(planner,sessions,library).md
+++ b/reports/13Apr_dashboard-page-responsive-design(planner,sessions,library).md
@@ -113,6 +113,47 @@
 - Minor landing page update in `frontend/app/page.tsx`.
 - Dependency lockfile updated: `frontend/package-lock.json`.
 
+### 5. Sessions view
+
+Branch name: 53-session-records-and-profile-settings-in-dashboard
+
+#### Backend
+- Added session lifecycle service: `backend/app/services/session_records_service.py`.
+	- `resolve_user_id_from_token`
+	- `start_live_session`
+	- `end_live_session`
+- Refactored websocket orchestration to use the new session service:
+	- session start/end handled via session events and disconnect fallback
+	- current slide index updates linked to active session
+- Extended presentations API in `backend/app/api/v1/presentations.py`:
+	- `GET /api/v1/presentations/sessions/recent`
+	- `DELETE /api/v1/presentations/sessions/{session_id}`
+	- session payload includes `duration_seconds` for precise UI rendering.
+
+#### Frontend
+- Dashboard data layer (`frontend/app/dashboard/DashboardContext.tsx`):
+	- fetches recent sessions from backend
+	- computes dashboard session metrics from real session data.
+- Live presentation page (`frontend/app/presentation/[id]/page.tsx`):
+	- websocket connection includes auth token
+	- session behavior keeps pause/resume in the same page as one session.
+- Sessions UI (`frontend/app/dashboard/sessions/Sessions.tsx`):
+	- added date + time columns (24-hour format)
+	- duration rendered as `mm:ss`
+	- actions moved to a three-dot dropdown (Delete / Present again / View)
+	- dropdown rendered with portal/fixed positioning to avoid layout and scroll shift.
+- My Presentations actions (`frontend/app/dashboard/page.tsx`):
+	- actions converted to a three-dot dropdown (Add to planner / View / Present again / Delete).
+- Analyze navigation consistency:
+	- `returnTo` query propagation added in upload, library, and dashboard entry points
+	- analyze page back button returns to source page when provided.
+
+#### Planner UX Polishing
+- Standardized dashboard/planner alerts to auto-dismiss in `3500ms`.
+- Removed current-day framed highlight in planner cells; retained marker as a dot only.
+- Moved today's marker dot next to the day number and increased visibility.
+- Planner now opens with the current day selected by default.
+
 ## Test Coverage
 - Added planner API test file: `backend/tests/test_planner.py`.
 - Scenario covered:


### PR DESCRIPTION
## Summary
<!-- What does this PR dsessiono? Why is it needed? -->
This PR enhances the dashboard/planner workflow with persistent presentation sessions, improved planner UX, and navigation/interaction refinements.
It is needed to make session tracking reliable, improve usability on planner/sessions screens, and reduce auth-related confusion during dashboard data loading.
## Changes
<!-- List the main changes made -->

- Added backend session lifecycle handling (start/end, duration calculation) with service-based refactor.
- Added session APIs for dashboard usage:
- GET /api/v1/presentations/sessions/recent
- DELETE /api/v1/presentations/sessions/{session_id}
- Updated frontend dashboard data flow to consume real session records and compute stats from backend session data.
-  Improved Sessions UI:
- date + 24h time display
- [mm:ss](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) duration display
- three-dot actions (Delete / Present again / View)
- portal/fixed-position dropdown to avoid layout/scroll issues
- Updated My Presentations actions to three-dot menu for consistency.
- Added returnTo query-based back navigation behavior for Analyze flow.
- Planner UX polish:
- alerts standardized to auto-dismiss
- current-day visual adjusted to dot-style marker
- planner opens with current day selected
- Updated branch report documentation with latest completed changes.

## Related Issue
<!-- Link the issue this PR closes -->
Closes #

## Type of Change
- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `chore` — infrastructure / tooling
- [x] `docs` — documentation
- [ ] `test` — tests only

## Checklist
- [x] Code follows project style (flake8 + black)
- [x] Tests added or updated
- [x] Documentation updated if needed
- [x] Docker build tested locally
- [x] No direct push to `main`