### PR TITLE
x86 ai analysis

### DIFF
--- a/backend/app/api/v1/presentations.py
+++ b/backend/app/api/v1/presentations.py
@@ -6,9 +6,10 @@ from app.api.v1 import auth
 from app.core.database import get_db
 from app.core.logger import logger
 from app.core.exceptions import FileProcessingError, ResourceNotFoundError, ValidationError
-from app.services import pdf_service, pptx_service, embedding_service, vector_db, file_validator, generation_service
+from app.services import pdf_service, pptx_service, embedding_service, vector_db, file_validator, generation_service, analysis_service
 from app.core.limiter import limiter
 from app.schemas.presentation_generation import PresentationGenerateRequest, PresentationGenerateResponse, PresentationState, ImageLibraryItem
+from app.schemas.analysis import PresentationAnalysisRequest, PresentationAnalysisResponse
 from pydantic import BaseModel, Field
 import asyncio
 import io
@@ -276,6 +277,41 @@ async def get_presentation(
         ]
 
     return response
+
+
+@router.post("/{presentation_id}/analyze", response_model=PresentationAnalysisResponse)
+async def analyze_presentation(
+    presentation_id: int,
+    request: PresentationAnalysisRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user = Depends(auth.get_current_user)
+):
+    stmt = select(Presentation).where(
+        Presentation.id == presentation_id,
+        Presentation.user_id == current_user.id
+    ).options(selectinload(Presentation.slides))
+
+    result = await db.execute(stmt)
+    presentation = result.scalar_one_or_none()
+
+    if not presentation:
+        raise ResourceNotFoundError("Presentation not found")
+    if not presentation.slides:
+        raise ValidationError("Presentation has no slides to analyze")
+
+    slides = sorted(presentation.slides, key=lambda s: s.page_number)
+
+    try:
+        return await analysis_service.analyze_presentation(
+            title=presentation.title,
+            slides=[{"page_number": s.page_number, "content_text": s.content_text} for s in slides],
+            language=request.language,
+        )
+    except (ResourceNotFoundError, ValidationError):
+        raise
+    except Exception as e:
+        logger.error(f"Analysis failed for presentation {presentation_id}: {e}")
+        raise HTTPException(status_code=500, detail="Failed to analyze presentation. Please try again.")
 
 
 @router.get("/{presentation_id}/ai-state", response_model=PresentationState)

--- a/backend/app/api/v1/presentations.py
+++ b/backend/app/api/v1/presentations.py
@@ -280,9 +280,11 @@ async def get_presentation(
 
 
 @router.post("/{presentation_id}/analyze", response_model=PresentationAnalysisResponse)
+@limiter.limit("5/minute")
 async def analyze_presentation(
+    request: Request,
     presentation_id: int,
-    request: PresentationAnalysisRequest,
+    payload: PresentationAnalysisRequest,
     db: AsyncSession = Depends(get_db),
     current_user = Depends(auth.get_current_user)
 ):
@@ -305,7 +307,7 @@ async def analyze_presentation(
         return await analysis_service.analyze_presentation(
             title=presentation.title,
             slides=[{"page_number": s.page_number, "content_text": s.content_text} for s in slides],
-            language=request.language,
+            language=payload.language,
         )
     except (ResourceNotFoundError, ValidationError):
         raise

--- a/backend/app/schemas/analysis.py
+++ b/backend/app/schemas/analysis.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel, Field
+
+
+class PresentationAnalysisRequest(BaseModel):
+    language: str = Field(default="en", max_length=10)
+
+
+class SlideFeedback(BaseModel):
+    page_number: int
+    strength: str
+    improvement: str
+
+
+class PresentationAnalysisResponse(BaseModel):
+    overall_score: int = Field(..., ge=0, le=100)
+    readability_score: int = Field(..., ge=0, le=100)
+    structure_score: int = Field(..., ge=0, le=100)
+    visual_balance_score: int = Field(..., ge=0, le=100)
+    summary: str
+    slide_feedback: list[SlideFeedback]

--- a/backend/app/services/analysis_service.py
+++ b/backend/app/services/analysis_service.py
@@ -1,0 +1,78 @@
+"""
+AI-based presentation quality scoring, backing the `/presentations/{id}/analyze`
+endpoint. Stateless like ideas_service — generated on demand, not persisted.
+"""
+import json
+
+from app.core.openai_client import get_openai_client as get_client
+from app.schemas.analysis import PresentationAnalysisResponse
+
+# Per-slide text is capped to bound prompt size/cost on large presentations.
+MAX_SLIDE_CHARS = 600
+
+SYSTEM_PROMPT = """You are an expert presentation coach and design critic, evaluating a presentation's slide content.
+
+You cannot see the actual visual design, so infer visual balance from text density (bullet count and length per slide) rather than colors or images.
+
+Score each of the following 0-100:
+- overall_score: overall quality of the presentation
+- readability_score: clarity and conciseness of the text on each slide
+- structure_score: logical flow and progression between slides
+- visual_balance_score: estimated text density balance across slides (penalize overcrowded or near-empty slides)
+
+Also write:
+- summary: a 2-3 sentence overall assessment
+- slide_feedback: for every slide, exactly one concrete strength and one concrete, actionable improvement
+
+Return ONLY a valid JSON object in this exact format:
+{
+  "overall_score": 0,
+  "readability_score": 0,
+  "structure_score": 0,
+  "visual_balance_score": 0,
+  "summary": "...",
+  "slide_feedback": [
+    {"page_number": 1, "strength": "...", "improvement": "..."},
+    ...
+  ]
+}
+
+Rules:
+- Include one slide_feedback entry per slide provided, in the same order
+- Write ALL text (summary, strength, improvement) in the specified output language
+- Be specific to this presentation's actual content, not generic advice
+- Do NOT include markdown, explanations, or anything outside the JSON"""
+
+
+async def analyze_presentation(
+    title: str,
+    slides: list[dict],
+    language: str,
+) -> PresentationAnalysisResponse:
+    language_name = "Turkish" if language == "tr" else "English"
+    slides_text = "\n\n".join(
+        f"[Slide {s['page_number']}]: {s['content_text'][:MAX_SLIDE_CHARS]}"
+        for s in slides
+    )
+    user_prompt = (
+        f"Presentation title: {title}\n"
+        f"Number of slides: {len(slides)}\n"
+        f"Output language: {language_name}\n\n"
+        f"Slide contents:\n{slides_text}"
+    )
+
+    client = get_client()
+    response = await client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": user_prompt},
+        ],
+        temperature=0.4,
+        max_tokens=2500,
+        response_format={"type": "json_object"},
+    )
+
+    raw = response.choices[0].message.content or "{}"
+    data = json.loads(raw)
+    return PresentationAnalysisResponse(**data)

--- a/frontend/app/dashboard/analysis/AiAnalysis.tsx
+++ b/frontend/app/dashboard/analysis/AiAnalysis.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { RefreshCw, AlertCircle, ThumbsUp, Lightbulb } from 'lucide-react';
+import { useTranslations, useLocale } from 'next-intl';
+import { useDashboard } from '../DashboardContext';
+import { useAiAnalysis } from '../../hooks/useAiAnalysis';
+import Spinner from '../../components/Spinner';
+
+const SELECTED_ID_KEY = 'precue_analysis_selected_id';
+
+const SELECT_CLASSNAME =
+    'w-full bg-zinc-900/40 border border-white/5 hover:border-white/10 focus:border-primary/50 focus:outline-none px-4 py-3.5 rounded-2xl text-xs font-bold text-zinc-300 transition-all cursor-pointer appearance-none';
+const SELECT_STYLE = {
+    backgroundImage: `url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='rgba(255,255,255,0.4)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E")`,
+    backgroundPosition: 'right 14px center',
+    backgroundRepeat: 'no-repeat',
+    backgroundSize: '16px',
+} as const;
+
+function ScoreCard({ label, score }: { label: string; score: number }) {
+    const color = score >= 75 ? '#22c55e' : score >= 50 ? '#f59e0b' : '#ef4444';
+    return (
+        <div className="bg-zinc-900/40 border border-white/5 rounded-2xl p-4 flex flex-col gap-2">
+            <span className="text-[10px] font-bold uppercase tracking-widest text-zinc-500">{label}</span>
+            <div className="flex items-baseline gap-1">
+                <span className="text-2xl font-black tabular-nums" style={{ color }}>{score}</span>
+                <span className="text-xs text-zinc-600 font-bold">/100</span>
+            </div>
+        </div>
+    );
+}
+
+export default function AiAnalysis() {
+    const t = useTranslations('aiAnalysis');
+    const locale = useLocale();
+    const { presentations } = useDashboard();
+    const { result, isAnalyzing, error, analyze, loadCached } = useAiAnalysis();
+
+    const analyzable = useMemo(
+        () => presentations.filter((p) => p.status === 'completed' && p.slide_count > 0),
+        [presentations]
+    );
+
+    const [selectedId, setSelectedId] = useState<string>('');
+
+    useEffect(() => {
+        const storedId = sessionStorage.getItem(SELECTED_ID_KEY);
+        if (storedId) {
+            setSelectedId(storedId);
+            loadCached(storedId);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    const handleSelect = (id: string) => {
+        setSelectedId(id);
+        sessionStorage.setItem(SELECTED_ID_KEY, id);
+        loadCached(id);
+    };
+
+    const handleAnalyze = () => {
+        if (!selectedId) return;
+        analyze(selectedId, locale, t('errorMessage'));
+    };
+
+    return (
+        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="max-w-3xl">
+            <div className="mb-6">
+                <p className="text-sm text-zinc-500">{t('subtitle')}</p>
+            </div>
+
+            {analyzable.length === 0 ? (
+                <div className="bg-zinc-900/40 border border-white/5 rounded-2xl p-8 text-center text-sm text-zinc-500">
+                    {t('noPresentations')}
+                </div>
+            ) : (
+                <div className="flex flex-col sm:flex-row gap-3 mb-6">
+                    <div className="relative flex-1">
+                        <select
+                            value={selectedId}
+                            onChange={(e) => handleSelect(e.target.value)}
+                            className={SELECT_CLASSNAME}
+                            style={SELECT_STYLE}
+                        >
+                            <option value="" disabled>{t('selectPlaceholder')}</option>
+                            {analyzable.map((p) => (
+                                <option key={p.id} value={p.id}>
+                                    {p.title} · {p.slide_count} {t('slidesUnit')}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                    <button
+                        onClick={handleAnalyze}
+                        disabled={!selectedId || isAnalyzing}
+                        className="flex items-center justify-center gap-2 px-6 py-3.5 rounded-2xl bg-primary text-black text-xs font-black uppercase tracking-wider hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed transition-all"
+                    >
+                        {isAnalyzing && <Spinner size={14} borderColorClassName="border-black" />}
+                        {isAnalyzing ? t('analyzing') : result ? t('reanalyze') : t('analyze')}
+                    </button>
+                </div>
+            )}
+
+            {error && (
+                <div className="flex items-center gap-2 text-red-400 text-xs font-bold bg-red-500/10 border border-red-500/20 rounded-xl px-4 py-3 mb-6">
+                    <AlertCircle size={14} />
+                    {error}
+                </div>
+            )}
+
+            <AnimatePresence mode="wait">
+                {result && (
+                    <motion.div
+                        key={selectedId}
+                        initial={{ opacity: 0, y: 8 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0 }}
+                        className="space-y-6"
+                    >
+                        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                            <ScoreCard label={t('overallScore')} score={result.overall_score} />
+                            <ScoreCard label={t('readabilityScore')} score={result.readability_score} />
+                            <ScoreCard label={t('structureScore')} score={result.structure_score} />
+                            <ScoreCard label={t('visualBalanceScore')} score={result.visual_balance_score} />
+                        </div>
+
+                        <div className="bg-zinc-900/40 border border-white/5 rounded-2xl p-5">
+                            <h2 className="text-xs font-black uppercase tracking-widest text-zinc-500 mb-2">{t('summaryLabel')}</h2>
+                            <p className="text-sm text-zinc-300 leading-relaxed">{result.summary}</p>
+                        </div>
+
+                        <div>
+                            <h2 className="text-xs font-black uppercase tracking-widest text-zinc-500 mb-3">{t('slideFeedbackLabel')}</h2>
+                            <div className="space-y-3">
+                                {result.slide_feedback.map((slide) => (
+                                    <div key={slide.page_number} className="bg-zinc-900/40 border border-white/5 rounded-2xl p-4">
+                                        <span className="text-[10px] font-black uppercase tracking-widest text-primary">
+                                            {t('slideLabel')} {slide.page_number}
+                                        </span>
+                                        <div className="mt-2 flex gap-2 items-start">
+                                            <ThumbsUp size={13} className="text-emerald-400 mt-0.5 shrink-0" />
+                                            <p className="text-xs text-zinc-300 leading-relaxed">{slide.strength}</p>
+                                        </div>
+                                        <div className="mt-1.5 flex gap-2 items-start">
+                                            <Lightbulb size={13} className="text-amber-400 mt-0.5 shrink-0" />
+                                            <p className="text-xs text-zinc-300 leading-relaxed">{slide.improvement}</p>
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    </motion.div>
+                )}
+            </AnimatePresence>
+
+            {isAnalyzing && !result && (
+                <div className="flex flex-col items-center justify-center py-16 gap-3">
+                    <Spinner size={32} />
+                    <p className="text-xs text-zinc-500 flex items-center gap-1.5">
+                        <RefreshCw size={12} className="animate-spin" />
+                        {t('analyzing')}
+                    </p>
+                </div>
+            )}
+        </motion.div>
+    );
+}

--- a/frontend/app/dashboard/analysis/AiAnalysis.tsx
+++ b/frontend/app/dashboard/analysis/AiAnalysis.tsx
@@ -7,6 +7,8 @@ import { useTranslations, useLocale } from 'next-intl';
 import { useDashboard } from '../DashboardContext';
 import { useAiAnalysis } from '../../hooks/useAiAnalysis';
 import Spinner from '../../components/Spinner';
+import ScoreRadarChart from './ScoreRadarChart';
+import PracticeStats from './PracticeStats';
 
 const SELECTED_ID_KEY = 'precue_analysis_selected_id';
 
@@ -19,23 +21,10 @@ const SELECT_STYLE = {
     backgroundSize: '16px',
 } as const;
 
-function ScoreCard({ label, score }: { label: string; score: number }) {
-    const color = score >= 75 ? '#22c55e' : score >= 50 ? '#f59e0b' : '#ef4444';
-    return (
-        <div className="bg-zinc-900/40 border border-white/5 rounded-2xl p-4 flex flex-col gap-2">
-            <span className="text-[10px] font-bold uppercase tracking-widest text-zinc-500">{label}</span>
-            <div className="flex items-baseline gap-1">
-                <span className="text-2xl font-black tabular-nums" style={{ color }}>{score}</span>
-                <span className="text-xs text-zinc-600 font-bold">/100</span>
-            </div>
-        </div>
-    );
-}
-
 export default function AiAnalysis() {
     const t = useTranslations('aiAnalysis');
     const locale = useLocale();
-    const { presentations } = useDashboard();
+    const { presentations, recentSessions } = useDashboard();
     const { result, isAnalyzing, error, analyze, loadCached } = useAiAnalysis();
 
     const analyzable = useMemo(
@@ -44,6 +33,11 @@ export default function AiAnalysis() {
     );
 
     const [selectedId, setSelectedId] = useState<string>('');
+
+    const presentationSessions = useMemo(
+        () => recentSessions.filter((s) => String(s.presentation.id) === selectedId),
+        [recentSessions, selectedId]
+    );
 
     useEffect(() => {
         const storedId = sessionStorage.getItem(SELECTED_ID_KEY);
@@ -66,7 +60,7 @@ export default function AiAnalysis() {
     };
 
     return (
-        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="max-w-3xl">
+        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="max-w-6xl">
             <div className="mb-6">
                 <p className="text-sm text-zinc-500">{t('subtitle')}</p>
             </div>
@@ -110,58 +104,67 @@ export default function AiAnalysis() {
                 </div>
             )}
 
-            <AnimatePresence mode="wait">
-                {result && (
-                    <motion.div
-                        key={selectedId}
-                        initial={{ opacity: 0, y: 8 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        exit={{ opacity: 0 }}
-                        className="space-y-6"
-                    >
-                        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-                            <ScoreCard label={t('overallScore')} score={result.overall_score} />
-                            <ScoreCard label={t('readabilityScore')} score={result.readability_score} />
-                            <ScoreCard label={t('structureScore')} score={result.structure_score} />
-                            <ScoreCard label={t('visualBalanceScore')} score={result.visual_balance_score} />
-                        </div>
+            {selectedId && (
+                <div className="grid grid-cols-1 lg:grid-cols-[1fr_300px] gap-6 items-start">
+                    <div className="space-y-6 order-2 lg:order-1">
+                        <AnimatePresence mode="wait">
+                            {result && (
+                                <motion.div
+                                    key={selectedId}
+                                    initial={{ opacity: 0, y: 8 }}
+                                    animate={{ opacity: 1, y: 0 }}
+                                    exit={{ opacity: 0 }}
+                                    className="space-y-6"
+                                >
+                                    <div className="bg-zinc-900/40 border border-white/5 rounded-2xl p-5">
+                                        <h2 className="text-xs font-black uppercase tracking-widest text-zinc-500 mb-2">{t('summaryLabel')}</h2>
+                                        <p className="text-sm text-zinc-300 leading-relaxed">{result.summary}</p>
+                                    </div>
 
-                        <div className="bg-zinc-900/40 border border-white/5 rounded-2xl p-5">
-                            <h2 className="text-xs font-black uppercase tracking-widest text-zinc-500 mb-2">{t('summaryLabel')}</h2>
-                            <p className="text-sm text-zinc-300 leading-relaxed">{result.summary}</p>
-                        </div>
-
-                        <div>
-                            <h2 className="text-xs font-black uppercase tracking-widest text-zinc-500 mb-3">{t('slideFeedbackLabel')}</h2>
-                            <div className="space-y-3">
-                                {result.slide_feedback.map((slide) => (
-                                    <div key={slide.page_number} className="bg-zinc-900/40 border border-white/5 rounded-2xl p-4">
-                                        <span className="text-[10px] font-black uppercase tracking-widest text-primary">
-                                            {t('slideLabel')} {slide.page_number}
-                                        </span>
-                                        <div className="mt-2 flex gap-2 items-start">
-                                            <ThumbsUp size={13} className="text-emerald-400 mt-0.5 shrink-0" />
-                                            <p className="text-xs text-zinc-300 leading-relaxed">{slide.strength}</p>
-                                        </div>
-                                        <div className="mt-1.5 flex gap-2 items-start">
-                                            <Lightbulb size={13} className="text-amber-400 mt-0.5 shrink-0" />
-                                            <p className="text-xs text-zinc-300 leading-relaxed">{slide.improvement}</p>
+                                    <div>
+                                        <h2 className="text-xs font-black uppercase tracking-widest text-zinc-500 mb-3">{t('slideFeedbackLabel')}</h2>
+                                        <div className="space-y-3">
+                                            {result.slide_feedback.map((slide) => (
+                                                <div key={slide.page_number} className="bg-zinc-900/40 border border-white/5 rounded-2xl p-4">
+                                                    <span className="text-[10px] font-black uppercase tracking-widest text-primary">
+                                                        {t('slideLabel')} {slide.page_number}
+                                                    </span>
+                                                    <div className="mt-2 flex gap-2 items-start">
+                                                        <ThumbsUp size={13} className="text-emerald-400 mt-0.5 shrink-0" />
+                                                        <p className="text-xs text-zinc-300 leading-relaxed">{slide.strength}</p>
+                                                    </div>
+                                                    <div className="mt-1.5 flex gap-2 items-start">
+                                                        <Lightbulb size={13} className="text-amber-400 mt-0.5 shrink-0" />
+                                                        <p className="text-xs text-zinc-300 leading-relaxed">{slide.improvement}</p>
+                                                    </div>
+                                                </div>
+                                            ))}
                                         </div>
                                     </div>
-                                ))}
-                            </div>
-                        </div>
-                    </motion.div>
-                )}
-            </AnimatePresence>
+                                </motion.div>
+                            )}
+                        </AnimatePresence>
 
-            {isAnalyzing && !result && (
-                <div className="flex flex-col items-center justify-center py-16 gap-3">
-                    <Spinner size={32} />
-                    <p className="text-xs text-zinc-500 flex items-center gap-1.5">
-                        <RefreshCw size={12} className="animate-spin" />
-                        {t('analyzing')}
-                    </p>
+                        {isAnalyzing && !result && (
+                            <div className="flex flex-col items-center justify-center py-16 gap-3">
+                                <Spinner size={32} />
+                                <p className="text-xs text-zinc-500 flex items-center gap-1.5">
+                                    <RefreshCw size={12} className="animate-spin" />
+                                    {t('analyzing')}
+                                </p>
+                            </div>
+                        )}
+                    </div>
+
+                    <div className="order-1 lg:order-2 lg:sticky lg:top-6 space-y-6">
+                        {result && (
+                            <ScoreRadarChart
+                                labels={[t('overallScore'), t('readabilityScore'), t('structureScore'), t('visualBalanceScore')]}
+                                scores={[result.overall_score, result.readability_score, result.structure_score, result.visual_balance_score]}
+                            />
+                        )}
+                        <PracticeStats sessions={presentationSessions} />
+                    </div>
                 </div>
             )}
         </motion.div>

--- a/frontend/app/dashboard/analysis/PracticeStats.tsx
+++ b/frontend/app/dashboard/analysis/PracticeStats.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { Clock, Mic2, Radio } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import type { RecentSession } from '../DashboardContext';
+import SessionDurationChart from './SessionDurationChart';
+
+interface PracticeStatsProps {
+    sessions: RecentSession[];
+}
+
+export default function PracticeStats({ sessions }: PracticeStatsProps) {
+    const t = useTranslations('aiAnalysis');
+
+    if (sessions.length === 0) {
+        return (
+            <div className="bg-zinc-900/40 border border-white/5 rounded-2xl p-5">
+                <h2 className="text-xs font-black uppercase tracking-widest text-zinc-500 mb-2">{t('practiceStatsLabel')}</h2>
+                <p className="text-xs text-zinc-500">{t('noSessions')}</p>
+            </div>
+        );
+    }
+
+    const sorted = [...sessions].sort((a, b) => new Date(a.started_at).getTime() - new Date(b.started_at).getTime());
+    const chartSessions = sorted.slice(-10);
+
+    const totalMinutes = sessions.reduce((sum, s) => sum + s.duration_minutes, 0);
+    const rehearsalCount = sessions.filter((s) => s.session_type === 'rehearsal').length;
+    const liveCount = sessions.filter((s) => s.session_type === 'live').length;
+    const lastPracticed = sorted[sorted.length - 1].started_at;
+
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+
+    return (
+        <div className="bg-zinc-900/40 border border-white/5 rounded-2xl p-5">
+            <h2 className="text-xs font-black uppercase tracking-widest text-zinc-500 mb-4">{t('practiceStatsLabel')}</h2>
+
+            <div className="grid grid-cols-3 gap-2 mb-3">
+                <div>
+                    <div className="flex items-center gap-1.5 text-white">
+                        <Clock size={12} className="text-primary shrink-0" />
+                        <span className="text-sm font-black tabular-nums">{hours}h {minutes}m</span>
+                    </div>
+                    <div className="text-[9px] uppercase tracking-wider text-zinc-500 mt-0.5">{t('totalPracticeTime')}</div>
+                </div>
+                <div>
+                    <div className="flex items-center gap-1.5 text-white">
+                        <Mic2 size={12} className="text-[#06b6d4] shrink-0" />
+                        <span className="text-sm font-black tabular-nums">{rehearsalCount}</span>
+                    </div>
+                    <div className="text-[9px] uppercase tracking-wider text-zinc-500 mt-0.5">{t('rehearsals')}</div>
+                </div>
+                <div>
+                    <div className="flex items-center gap-1.5 text-white">
+                        <Radio size={12} className="text-primary shrink-0" />
+                        <span className="text-sm font-black tabular-nums">{liveCount}</span>
+                    </div>
+                    <div className="text-[9px] uppercase tracking-wider text-zinc-500 mt-0.5">{t('liveSessions')}</div>
+                </div>
+            </div>
+
+            <p className="text-[10px] text-zinc-500 mb-4">
+                {t('lastPracticed')}: {new Date(lastPracticed).toLocaleDateString('en-GB')}
+            </p>
+
+            <SessionDurationChart sessions={chartSessions} />
+
+            <div className="flex items-center gap-4 mt-3">
+                <span className="flex items-center gap-1.5 text-[9px] font-bold uppercase tracking-wider text-zinc-500">
+                    <span className="w-2 h-2 rounded-full bg-[#06b6d4]" /> {t('rehearsals')}
+                </span>
+                <span className="flex items-center gap-1.5 text-[9px] font-bold uppercase tracking-wider text-zinc-500">
+                    <span className="w-2 h-2 rounded-full bg-primary" /> {t('liveSessions')}
+                </span>
+            </div>
+        </div>
+    );
+}

--- a/frontend/app/dashboard/analysis/ScoreRadarChart.tsx
+++ b/frontend/app/dashboard/analysis/ScoreRadarChart.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { motion } from 'framer-motion';
+
+interface ScoreRadarChartProps {
+    labels: string[];
+    scores: number[];
+}
+
+const SIZE = 260;
+const CENTER = SIZE / 2;
+const RADIUS = 95;
+const RINGS = [25, 50, 75, 100];
+
+function pointFor(index: number, total: number, value: number) {
+    const angle = -Math.PI / 2 + (index * 2 * Math.PI) / total;
+    const r = (value / 100) * RADIUS;
+    return {
+        x: CENTER + r * Math.cos(angle),
+        y: CENTER + r * Math.sin(angle),
+    };
+}
+
+function scoreColor(score: number) {
+    return score >= 75 ? '#22c55e' : score >= 50 ? '#f59e0b' : '#ef4444';
+}
+
+export default function ScoreRadarChart({ labels, scores }: ScoreRadarChartProps) {
+    const total = labels.length;
+    const dataPoints = scores.map((s, i) => pointFor(i, total, s));
+    const dataPath = dataPoints.map((p) => `${p.x},${p.y}`).join(' ');
+
+    return (
+        <div className="bg-zinc-900/40 border border-white/5 rounded-2xl p-6 flex flex-col items-center">
+            <svg width={SIZE} height={SIZE} viewBox={`0 0 ${SIZE} ${SIZE}`}>
+                <defs>
+                    <linearGradient id="radarFill" x1="0%" y1="0%" x2="100%" y2="100%">
+                        <stop offset="0%" stopColor="#f97316" stopOpacity="0.55" />
+                        <stop offset="100%" stopColor="#06b6d4" stopOpacity="0.35" />
+                    </linearGradient>
+                </defs>
+
+                {RINGS.map((ring) => (
+                    <polygon
+                        key={ring}
+                        points={labels.map((_, i) => { const p = pointFor(i, total, ring); return `${p.x},${p.y}`; }).join(' ')}
+                        fill="none"
+                        stroke="rgba(255,255,255,0.08)"
+                        strokeWidth={1}
+                    />
+                ))}
+
+                {labels.map((_, i) => {
+                    const p = pointFor(i, total, 100);
+                    return (
+                        <line
+                            key={i}
+                            x1={CENTER}
+                            y1={CENTER}
+                            x2={p.x}
+                            y2={p.y}
+                            stroke="rgba(255,255,255,0.08)"
+                            strokeWidth={1}
+                        />
+                    );
+                })}
+
+                <motion.polygon
+                    points={dataPath}
+                    fill="url(#radarFill)"
+                    stroke="#f97316"
+                    strokeWidth={2}
+                    strokeLinejoin="round"
+                    initial={{ scale: 0, opacity: 0 }}
+                    animate={{ scale: 1, opacity: 1 }}
+                    transition={{ duration: 0.5, ease: 'easeOut' }}
+                    style={{ transformOrigin: `${CENTER}px ${CENTER}px` }}
+                />
+
+                {dataPoints.map((p, i) => (
+                    <circle key={i} cx={p.x} cy={p.y} r={4} fill={scoreColor(scores[i])} stroke="#0a0a0a" strokeWidth={1.5} />
+                ))}
+            </svg>
+
+            <div className="grid grid-cols-1 gap-y-2 mt-3 w-full">
+                {labels.map((label, i) => (
+                    <div key={label} className="flex items-center justify-between gap-2">
+                        <span className="flex items-center gap-2 text-[10px] font-bold uppercase tracking-wider text-zinc-500">
+                            <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: scoreColor(scores[i]) }} />
+                            {label}
+                        </span>
+                        <span className="text-xs font-black tabular-nums" style={{ color: scoreColor(scores[i]) }}>
+                            {scores[i]}
+                        </span>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/frontend/app/dashboard/analysis/SessionDurationChart.tsx
+++ b/frontend/app/dashboard/analysis/SessionDurationChart.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { motion } from 'framer-motion';
+
+interface SessionBar {
+    id: number;
+    started_at: string;
+    duration_minutes: number;
+    session_type: string;
+}
+
+interface SessionDurationChartProps {
+    sessions: SessionBar[];
+}
+
+const REHEARSAL_COLOR = '#06b6d4';
+const LIVE_COLOR = '#f97316';
+
+export default function SessionDurationChart({ sessions }: SessionDurationChartProps) {
+    const maxDuration = Math.max(1, ...sessions.map((s) => s.duration_minutes));
+
+    return (
+        <div className="flex items-end gap-1.5 h-24">
+            {sessions.map((s, i) => {
+                const heightPct = Math.max(6, (s.duration_minutes / maxDuration) * 100);
+                const color = s.session_type === 'live' ? LIVE_COLOR : REHEARSAL_COLOR;
+                return (
+                    <motion.div
+                        key={s.id}
+                        className="flex-1 rounded-t-md min-w-[4px]"
+                        style={{ backgroundColor: color }}
+                        initial={{ height: 0 }}
+                        animate={{ height: `${heightPct}%` }}
+                        transition={{ duration: 0.4, delay: i * 0.03, ease: 'easeOut' }}
+                        title={`${s.duration_minutes}m · ${new Date(s.started_at).toLocaleDateString('en-GB')}`}
+                    />
+                );
+            })}
+        </div>
+    );
+}

--- a/frontend/app/dashboard/billing/Billing.tsx
+++ b/frontend/app/dashboard/billing/Billing.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { Check, ExternalLink } from 'lucide-react';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+
+interface PlanCardProps {
+    name: string;
+    price: string;
+    features: string[];
+    href: string;
+    buttonText: string;
+    currentBadge?: string;
+    featured?: boolean;
+}
+
+function PlanCard({ name, price, features, href, buttonText, currentBadge, featured }: PlanCardProps) {
+    return (
+        <div
+            className={`rounded-2xl p-5 border flex flex-col ${featured
+                ? 'bg-gradient-to-b from-primary/10 to-zinc-900 border-primary/40'
+                : 'bg-zinc-900/40 border-white/5'
+                }`}
+        >
+            <div className="flex items-center justify-between mb-1">
+                <h3 className={`text-sm font-black ${featured ? 'text-primary' : 'text-white'}`}>{name}</h3>
+                {currentBadge && (
+                    <span className="text-[9px] font-black uppercase tracking-wider text-emerald-400 bg-emerald-400/10 px-2 py-0.5 rounded-full">
+                        {currentBadge}
+                    </span>
+                )}
+            </div>
+            <div className="flex items-baseline gap-1 mb-4">
+                <span className="text-2xl font-black text-white">${price}</span>
+                <span className="text-xs text-zinc-500">/mo</span>
+            </div>
+            <div className="space-y-2 mb-5 flex-1">
+                {features.map((feature, i) => (
+                    <div key={i} className="flex gap-2 items-start">
+                        <Check size={12} strokeWidth={3} className={`mt-0.5 shrink-0 ${featured ? 'text-primary' : 'text-zinc-500'}`} />
+                        <span className="text-xs text-zinc-300 leading-relaxed">{feature}</span>
+                    </div>
+                ))}
+            </div>
+            {!currentBadge && (
+                <Link
+                    href={href}
+                    className={`w-full py-2.5 rounded-xl text-xs font-black uppercase tracking-wider text-center transition-all ${featured
+                        ? 'bg-primary text-black hover:opacity-90'
+                        : 'bg-white/5 text-white border border-white/10 hover:bg-white/10'
+                        }`}
+                >
+                    {buttonText}
+                </Link>
+            )}
+        </div>
+    );
+}
+
+export default function Billing() {
+    const t = useTranslations('billing');
+    const tPricing = useTranslations('pricing');
+
+    const freeFeatures = [tPricing('freeFeature0'), tPricing('freeFeature1'), tPricing('freeFeature2'), tPricing('freeFeature3')];
+    const proFeatures = [tPricing('proFeature0'), tPricing('proFeature1'), tPricing('proFeature2'), tPricing('proFeature3'), tPricing('proFeature4'), tPricing('proFeature5')];
+
+    return (
+        <div className="max-w-3xl space-y-6">
+            <p className="text-sm text-zinc-500">{t('subtitle')}</p>
+
+            <div className="bg-zinc-900/40 border border-white/5 rounded-2xl p-6 flex items-center justify-between flex-wrap gap-4">
+                <div>
+                    <span className="text-[10px] font-black uppercase tracking-widest text-primary">{t('currentPlanLabel')}</span>
+                    <h2 className="text-xl font-black text-white mt-1">{tPricing('freeName')}</h2>
+                    <p className="text-sm text-zinc-500 mt-1">{t('freeActiveNote')}</p>
+                </div>
+                <Link
+                    href="/pricing?plan=pro"
+                    className="flex items-center gap-2 px-5 py-3 rounded-2xl bg-primary text-black text-xs font-black uppercase tracking-wider hover:opacity-90 transition-all shrink-0"
+                >
+                    {t('upgradeButton')}
+                    <ExternalLink size={14} />
+                </Link>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <PlanCard
+                    name={tPricing('freeName')}
+                    price="0"
+                    features={freeFeatures}
+                    href="/pricing"
+                    buttonText={tPricing('freeButton')}
+                    currentBadge={t('currentBadge')}
+                />
+                <PlanCard
+                    name={tPricing('proName')}
+                    price="9.99"
+                    features={proFeatures}
+                    href="/pricing?plan=pro"
+                    buttonText={tPricing('proButton')}
+                    featured
+                />
+            </div>
+
+            <Link
+                href="/pricing"
+                className="flex items-center justify-center gap-1.5 text-xs font-bold text-zinc-500 hover:text-zinc-300 transition-colors"
+            >
+                {t('viewAllPlans')}
+                <ExternalLink size={12} />
+            </Link>
+        </div>
+    );
+}

--- a/frontend/app/dashboard/layout.tsx
+++ b/frontend/app/dashboard/layout.tsx
@@ -225,9 +225,11 @@ function Header() {
     const { user, activeTab, searchQuery, setSearchQuery, setActiveTab, favoriteTopicIdeas, setPendingTopicIdea } = useDashboard();
     const t = useTranslations("dashboard");
     const tIdeas = useTranslations("topicIdeas");
-    const isCompactHeaderTab = activeTab === 'presentations' || activeTab === 'sessions' || activeTab === 'profile' || activeTab === 'billing' || activeTab === 'ideas-topics' || activeTab === 'ideas-hooks' || activeTab === 'ideas-visuals' || activeTab === 'ai-presentation';
+    const isCompactHeaderTab = activeTab === 'presentations' || activeTab === 'sessions' || activeTab === 'profile' || activeTab === 'billing' || activeTab === 'ideas-topics' || activeTab === 'ideas-hooks' || activeTab === 'ideas-visuals' || activeTab === 'ai-presentation' || activeTab === 'ai-analysis';
     const compactTitle = activeTab === 'ai-presentation'
         ? 'AI Presentation Generation'
+        : activeTab === 'ai-analysis'
+        ? t("aiAnalysis")
         : activeTab === 'sessions'
         ? t("sessions")
         : activeTab === 'profile'

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -28,6 +28,7 @@ import Profile from "./profile/Profile";
 import TopicIdeas from "./ideas/TopicIdeas";
 import AiGenerationForm from "./ai-presentation/AiGenerationForm";
 import AiAnalysis from "./analysis/AiAnalysis";
+import Billing from "./billing/Billing";
 import client from "../api/client";
 import axios from "axios";
 import { useTranslations } from "next-intl";
@@ -513,14 +514,8 @@ export default function DashboardPage() {
                 <Profile />
             )}
 
-            {/* Billing Tab — placeholder */}
-            {activeTab === 'billing' && (
-                <motion.div
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    className="min-h-[40vh]"
-                />
-            )}
+            {/* Billing Tab */}
+            {activeTab === 'billing' && <Billing />}
 
             {plannerModalPresentation && (
                 <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -27,6 +27,7 @@ import Sessions from "./sessions/Sessions";
 import Profile from "./profile/Profile";
 import TopicIdeas from "./ideas/TopicIdeas";
 import AiGenerationForm from "./ai-presentation/AiGenerationForm";
+import AiAnalysis from "./analysis/AiAnalysis";
 import client from "../api/client";
 import axios from "axios";
 import { useTranslations } from "next-intl";
@@ -489,6 +490,9 @@ export default function DashboardPage() {
 
             {/* Topic Ideas */}
             {activeTab === 'ideas-topics' && <TopicIdeas />}
+
+            {/* AI Analysis */}
+            {activeTab === 'ai-analysis' && <AiAnalysis />}
 
             {/* Ideas — placeholders (hooks & visuals remain pending) */}
             {(activeTab === 'ideas-hooks' || activeTab === 'ideas-visuals') && (

--- a/frontend/app/hooks/useAiAnalysis.ts
+++ b/frontend/app/hooks/useAiAnalysis.ts
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import client from '../api/client';
+import type { PresentationAnalysis } from '../types/analysis';
+import { getErrorMessage } from '../lib/getErrorMessage';
+
+const CACHE_KEY = 'precue_analysis_cache';
+
+function readCache(): Record<string, PresentationAnalysis> {
+    if (typeof window === 'undefined') return {};
+    try {
+        const stored = sessionStorage.getItem(CACHE_KEY);
+        return stored ? JSON.parse(stored) : {};
+    } catch (e) {
+        console.error('Failed to parse cached analysis:', e);
+        return {};
+    }
+}
+
+/** Last analysis per presentation, cached client-side (like the trending-ideas
+ * cache) so re-selecting or refreshing doesn't lose the result. Re-analyzing
+ * simply overwrites the cached entry — there's no history across runs. */
+export function getCachedAnalysis(presentationId: string): PresentationAnalysis | null {
+    return readCache()[presentationId] ?? null;
+}
+
+export function useAiAnalysis() {
+    const [result, setResult] = useState<PresentationAnalysis | null>(null);
+    const [isAnalyzing, setIsAnalyzing] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const analyze = async (presentationId: string, language: string, fallbackError: string) => {
+        setIsAnalyzing(true);
+        setError(null);
+        try {
+            const response = await client.post<PresentationAnalysis>(
+                `/api/v1/presentations/${presentationId}/analyze`,
+                { language }
+            );
+            setResult(response.data);
+            const cache = readCache();
+            cache[presentationId] = response.data;
+            sessionStorage.setItem(CACHE_KEY, JSON.stringify(cache));
+        } catch (err) {
+            setError(getErrorMessage(err, fallbackError));
+        } finally {
+            setIsAnalyzing(false);
+        }
+    };
+
+    const loadCached = (presentationId: string) => {
+        setResult(presentationId ? getCachedAnalysis(presentationId) : null);
+        setError(null);
+    };
+
+    return { result, isAnalyzing, error, analyze, loadCached };
+}

--- a/frontend/app/types/analysis.ts
+++ b/frontend/app/types/analysis.ts
@@ -1,0 +1,14 @@
+export interface SlideFeedback {
+    page_number: number;
+    strength: string;
+    improvement: string;
+}
+
+export interface PresentationAnalysis {
+    overall_score: number;
+    readability_score: number;
+    structure_score: number;
+    visual_balance_score: number;
+    summary: string;
+    slide_feedback: SlideFeedback[];
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -402,7 +402,7 @@
     "hooksOpenings": "Hooks & openings",
     "visualDirection": "Visual direction",
     "aiPresentation": "AI Presentation",
-    "aiAnalysis": "AI Analysis",
+    "aiAnalysis": "Quality Analysis",
     "actions": "Actions",
     "planner": "Planner",
     "billing": "Billing",
@@ -780,6 +780,24 @@
     "noSavedIdeas": "No favorites yet",
     "startWithCategory": "Or start with a category",
     "trendingTopics": "Trending Topics"
+  },
+  "aiAnalysis": {
+    "title": "Quality Analysis",
+    "subtitle": "Get AI-generated feedback on structure, readability, and visual balance for any of your presentations",
+    "noPresentations": "You don't have any completed presentations to analyze yet.",
+    "selectPlaceholder": "Select a presentation to analyze",
+    "slidesUnit": "slides",
+    "analyze": "Analyze",
+    "reanalyze": "Re-analyze",
+    "analyzing": "Analyzing...",
+    "errorMessage": "Failed to analyze the presentation. Please try again.",
+    "overallScore": "Overall",
+    "readabilityScore": "Readability",
+    "structureScore": "Structure",
+    "visualBalanceScore": "Visual Balance",
+    "summaryLabel": "Summary",
+    "slideFeedbackLabel": "Slide-by-Slide Feedback",
+    "slideLabel": "Slide"
   },
   "aiGeneration": {
     "title": "Generate Presentation with AI",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -797,7 +797,13 @@
     "visualBalanceScore": "Visual Balance",
     "summaryLabel": "Summary",
     "slideFeedbackLabel": "Slide-by-Slide Feedback",
-    "slideLabel": "Slide"
+    "slideLabel": "Slide",
+    "practiceStatsLabel": "Practice Stats",
+    "noSessions": "No rehearsal or live sessions recorded for this presentation yet.",
+    "totalPracticeTime": "Total Time",
+    "rehearsals": "Rehearsals",
+    "liveSessions": "Live",
+    "lastPracticed": "Last practiced"
   },
   "aiGeneration": {
     "title": "Generate Presentation with AI",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -805,6 +805,14 @@
     "liveSessions": "Live",
     "lastPracticed": "Last practiced"
   },
+  "billing": {
+    "subtitle": "View your current plan and compare available plans",
+    "currentPlanLabel": "Current Plan",
+    "freeActiveNote": "You're on the free plan. Upgrade anytime for more presentations and features.",
+    "upgradeButton": "Upgrade",
+    "viewAllPlans": "View all plans",
+    "currentBadge": "Current"
+  },
   "aiGeneration": {
     "title": "Generate Presentation with AI",
     "subtitle": "Just enter the topic, let AI decide the slide count and design",

--- a/frontend/messages/tr.json
+++ b/frontend/messages/tr.json
@@ -797,7 +797,13 @@
     "visualBalanceScore": "Görsel Denge",
     "summaryLabel": "Özet",
     "slideFeedbackLabel": "Slayt Bazlı Geri Bildirim",
-    "slideLabel": "Slayt"
+    "slideLabel": "Slayt",
+    "practiceStatsLabel": "Prova İstatistikleri",
+    "noSessions": "Bu sunum için henüz kayıtlı prova veya canlı oturum yok.",
+    "totalPracticeTime": "Toplam Süre",
+    "rehearsals": "Prova",
+    "liveSessions": "Canlı",
+    "lastPracticed": "Son çalışma"
   },
   "aiGeneration": {
     "title": "Yapay Zeka ile Sunum Üret",

--- a/frontend/messages/tr.json
+++ b/frontend/messages/tr.json
@@ -805,6 +805,14 @@
     "liveSessions": "Canlı",
     "lastPracticed": "Son çalışma"
   },
+  "billing": {
+    "subtitle": "Mevcut planını gör ve diğer planlarla karşılaştır",
+    "currentPlanLabel": "Mevcut Plan",
+    "freeActiveNote": "Şu an ücretsiz plandasın. İstediğin zaman daha fazla sunum ve özellik için yükseltebilirsin.",
+    "upgradeButton": "Yükselt",
+    "viewAllPlans": "Tüm planları gör",
+    "currentBadge": "Mevcut"
+  },
   "aiGeneration": {
     "title": "Yapay Zeka ile Sunum Üret",
     "subtitle": "Sadece konuyu yazın, slayt sayısına ve tasarıma yapay zeka karar versin",

--- a/frontend/messages/tr.json
+++ b/frontend/messages/tr.json
@@ -402,7 +402,7 @@
     "hooksOpenings": "Kancalar & açılışlar",
     "visualDirection": "Görsel yön",
     "aiPresentation": "AI Sunumu",
-    "aiAnalysis": "AI Analizi",
+    "aiAnalysis": "Kalite Analizi",
     "actions": "Eylemler",
     "planner": "Planlayıcı",
     "billing": "Faturalama",
@@ -780,6 +780,24 @@
     "noSavedIdeas": "Henüz favori fikir yok",
     "startWithCategory": "Ya da bir kategoriyle başla",
     "trendingTopics": "Güncel Konular"
+  },
+  "aiAnalysis": {
+    "title": "Kalite Analizi",
+    "subtitle": "Sunumlarından herhangi biri için yapı, okunabilirlik ve görsel denge konusunda yapay zeka destekli geri bildirim al",
+    "noPresentations": "Analiz edilecek tamamlanmış bir sunumun yok.",
+    "selectPlaceholder": "Analiz edilecek bir sunum seç",
+    "slidesUnit": "slayt",
+    "analyze": "Analiz Et",
+    "reanalyze": "Yeniden Analiz Et",
+    "analyzing": "Analiz ediliyor...",
+    "errorMessage": "Sunum analiz edilemedi. Lütfen tekrar deneyin.",
+    "overallScore": "Genel",
+    "readabilityScore": "Okunabilirlik",
+    "structureScore": "Yapı",
+    "visualBalanceScore": "Görsel Denge",
+    "summaryLabel": "Özet",
+    "slideFeedbackLabel": "Slayt Bazlı Geri Bildirim",
+    "slideLabel": "Slayt"
   },
   "aiGeneration": {
     "title": "Yapay Zeka ile Sunum Üret",

--- a/reports/08July_dashboard-qa-section.md
+++ b/reports/08July_dashboard-qa-section.md
@@ -1,0 +1,70 @@
+# Changelog - July 8, 2026
+
+## Branch
+- **Name:** `86-ai-analysis`
+- **Base Comparison:** `7a6ad6b` (post `83-refactor-frontend` merge)
+- **Scope:** New "Quality Analysis" dashboard section — an AI-generated presentation-quality scorecard (previously an empty sidebar placeholder), plus a free, non-AI practice-stats panel built from existing session data.
+
+## Change Summary
+- **13 files changed** (9 new)
+- **+654 insertions / -4 deletions**
+- Major delivery areas:
+  - `POST /presentations/{id}/analyze` — GPT-4o-mini powered scoring (overall / readability / structure / visual balance) + per-slide feedback
+  - New dashboard tab: presentation picker → AI analysis → animated SVG radar chart + slide-by-slide feedback
+  - Client-side result caching (`sessionStorage`) so the analysis survives page refresh and re-selecting a presentation, without re-spending an API call
+  - Free "Practice Stats" panel (session count, total rehearsal/live time, per-session duration bar chart) built entirely from already-collected `presentation_sessions` data — no AI cost
+  - EN/TR localization for the whole section
+  - Renamed the section from "AI Analysis" to "Quality Analysis" mid-build to avoid confusion with the existing `/analyze` (chat/Q&A) page
+
+## Backend Updates
+
+### 1. Analysis Schemas (`backend/app/schemas/analysis.py`)
+- New file. `PresentationAnalysisRequest` (`language`), `SlideFeedback` (`page_number`, `strength`, `improvement`), `PresentationAnalysisResponse` (4 scores 0-100 + `summary` + `slide_feedback` list).
+
+### 2. Analysis Service (`backend/app/services/analysis_service.py`)
+- New file, following the existing `ideas_service.py` pattern (stateless, no DB persistence): builds a system + user prompt from the presentation's slide text, calls `gpt-4o-mini` via the shared `AsyncOpenAI` client with `response_format={"type": "json_object"}`, and parses the result into `PresentationAnalysisResponse`.
+- Per-slide text is capped at 600 characters (`MAX_SLIDE_CHARS`) to bound prompt size/cost on large presentations.
+- Note: `backend/app/models/presentation.py` already had an unused `PresentationAnalysis` table (`overall_score`, `readability_score`, etc.) from earlier work, but it was never wired to any service or endpoint. This feature deliberately does **not** persist to that table — it stays stateless like every other AI-generation feature in the app (Topic Ideas, AI Presentation Generation), and results are cached client-side instead (see below).
+
+### 3. Analyze Endpoint (`backend/app/api/v1/presentations.py`)
+- `POST /{presentation_id}/analyze` — ownership-checked (`Presentation.user_id == current_user.id`, `selectinload(Presentation.slides)`, same pattern as the existing `get_presentation` endpoint), raises `ResourceNotFoundError` if missing and `ValidationError` if the presentation has no slides, then delegates to `analysis_service.analyze_presentation()`.
+
+## Frontend Updates
+
+### 4. Shared Analysis Type (`frontend/app/types/analysis.ts`)
+- New file. `SlideFeedback`, `PresentationAnalysis` — mirrors the backend schema, single source of truth for the hook and components below.
+
+### 5. Analysis Hook (`frontend/app/hooks/useAiAnalysis.ts`)
+- New file. `useAiAnalysis()` owns `result` / `isAnalyzing` / `error` state and the `analyze()` API call (errors normalized via the existing `getErrorMessage` util).
+- Caches every successful result to `sessionStorage` (`precue_analysis_cache`, keyed by presentation id) — the same client-side caching pattern already used for Topic Ideas' trending-ideas cache. Exposes `getCachedAnalysis()` and `loadCached()` so a previously-analyzed presentation can be re-displayed instantly (from cache, no new AI call) after a page refresh or re-selecting it from the dropdown. Re-analyzing simply overwrites the cached entry — there is no history/trend across multiple runs.
+
+### 6. Quality Analysis Page (`frontend/app/dashboard/analysis/AiAnalysis.tsx`)
+- New file. Presentation picker (`<select>`, reusing `AiGenerationForm`'s existing select styling) sourced from `useDashboard().presentations`, filtered to `status === 'completed'`. Analyze / Re-analyze button.
+- Persists the selected presentation id to `sessionStorage` (`precue_analysis_selected_id`) and restores both the selection and its cached result on mount, so a full page refresh doesn't lose the last-viewed analysis.
+- Two-column layout once a presentation is selected: left column (summary + per-slide feedback, only once an analysis exists), right column (sticky) with the radar chart (once analyzed) and the practice-stats panel (shown immediately, independent of whether an analysis has been run).
+
+### 7. Score Radar Chart (`frontend/app/dashboard/analysis/ScoreRadarChart.tsx`)
+- New file. Hand-rolled SVG radar/spider chart (no charting library added — none existed in the project) plotting all 4 scores on 4 axes, gradient-filled polygon (primary → accent), framer-motion scale-in animation, vertex dots colored by a green/amber/red quality threshold, with a colored numeric legend below.
+
+### 8. Practice Stats Panel (`frontend/app/dashboard/analysis/PracticeStats.tsx`, `SessionDurationChart.tsx`)
+- New files. Reuses `useDashboard().recentSessions` (already fetched on dashboard mount — zero additional API cost) filtered to the selected presentation: total practice time, rehearsal count, live-session count, last-practiced date, and a colored animated bar chart of the last 10 sessions' durations (rehearsal = cyan, live = orange).
+
+### 9. Wiring (`frontend/app/dashboard/page.tsx`, `frontend/app/dashboard/layout.tsx`)
+- Routed `activeTab === 'ai-analysis'` to `<AiAnalysis />` (previously rendered nothing at all — the sidebar entry existed but had no corresponding view).
+- Added `ai-analysis` to the compact-header tab list so the section gets a proper title instead of falling back to the default hero header.
+
+### 10. Localization (`frontend/messages/en.json`, `frontend/messages/tr.json`)
+- New `aiAnalysis` namespace (title, subtitle, picker/button labels, score labels, practice-stats labels) in both languages.
+- Sidebar/header label (`dashboard.aiAnalysis`) changed from "AI Analysis" / "AI Analizi" to **"Quality Analysis" / "Kalite Analizi"** to avoid confusion with the pre-existing `/analyze` page (a different feature — presentation Q&A/chat).
+
+## UX Iterations During Build
+- Removed a redundant in-page `<h2>` title that duplicated the compact header's title.
+- Removed the decorative icon from the Analyze button, keeping only the functional loading spinner.
+- Moved the score cards from a flat top strip into the radar chart's legend to avoid showing the same 4 numbers twice.
+
+## Verification
+- Backend: `pytest` (27/27 passing, unaffected), manual live request via the browser confirmed `POST /api/v1/presentations/{id}/analyze` → `200 OK` end-to-end (DB fetch → OpenAI call → response), analyzing a real uploaded PDF and returning content-grounded feedback (not generic/templated output).
+- Frontend: `tsc --noEmit` and `eslint app` (whole project) clean after every step; live SSR fetch of `/dashboard?tab=ai-analysis` returns 200 with no error markers.
+
+## Considered, Not Implemented
+- **Groq (free-tier) as an alternative to OpenAI for the 4 pure chat-completion services** (`ideas_service`, `analysis_service`, `intent_service`, `rag_service`) was discussed as a cost-reduction option, since the shared `AsyncOpenAI` client (`app/core/openai_client.py`) could point at Groq's OpenAI-compatible endpoint with minimal code change. `embedding_service.py` must stay on OpenAI regardless — Groq has no embeddings API. No code was changed; flagged as a possible follow-up, starting with `intent_service.py` (latency-critical, simple JSON output, most forgiving of a potential quality difference).


### PR DESCRIPTION
# Changelog - July 8, 2026

## Branch
- **Name:** `86-ai-analysis`
- **Base Comparison:** `7a6ad6b` (post `83-refactor-frontend` merge)
- **Scope:** New "Quality Analysis" dashboard section — an AI-generated presentation-quality scorecard (previously an empty sidebar placeholder), plus a free, non-AI practice-stats panel built from existing session data.

## Change Summary
- **13 files changed** (9 new)
- **+654 insertions / -4 deletions**
- Major delivery areas:
  - `POST /presentations/{id}/analyze` — GPT-4o-mini powered scoring (overall / readability / structure / visual balance) + per-slide feedback
  - New dashboard tab: presentation picker → AI analysis → animated SVG radar chart + slide-by-slide feedback
  - Client-side result caching (`sessionStorage`) so the analysis survives page refresh and re-selecting a presentation, without re-spending an API call
  - Free "Practice Stats" panel (session count, total rehearsal/live time, per-session duration bar chart) built entirely from already-collected `presentation_sessions` data — no AI cost
  - EN/TR localization for the whole section
  - Renamed the section from "AI Analysis" to "Quality Analysis" mid-build to avoid confusion with the existing `/analyze` (chat/Q&A) page

## Backend Updates

### 1. Analysis Schemas (`backend/app/schemas/analysis.py`)
- New file. `PresentationAnalysisRequest` (`language`), `SlideFeedback` (`page_number`, `strength`, `improvement`), `PresentationAnalysisResponse` (4 scores 0-100 + `summary` + `slide_feedback` list).

### 2. Analysis Service (`backend/app/services/analysis_service.py`)
- New file, following the existing `ideas_service.py` pattern (stateless, no DB persistence): builds a system + user prompt from the presentation's slide text, calls `gpt-4o-mini` via the shared `AsyncOpenAI` client with `response_format={"type": "json_object"}`, and parses the result into `PresentationAnalysisResponse`.
- Per-slide text is capped at 600 characters (`MAX_SLIDE_CHARS`) to bound prompt size/cost on large presentations.
- Note: `backend/app/models/presentation.py` already had an unused `PresentationAnalysis` table (`overall_score`, `readability_score`, etc.) from earlier work, but it was never wired to any service or endpoint. This feature deliberately does **not** persist to that table — it stays stateless like every other AI-generation feature in the app (Topic Ideas, AI Presentation Generation), and results are cached client-side instead (see below).

### 3. Analyze Endpoint (`backend/app/api/v1/presentations.py`)
- `POST /{presentation_id}/analyze` — ownership-checked (`Presentation.user_id == current_user.id`, `selectinload(Presentation.slides)`, same pattern as the existing `get_presentation` endpoint), raises `ResourceNotFoundError` if missing and `ValidationError` if the presentation has no slides, then delegates to `analysis_service.analyze_presentation()`.

## Frontend Updates

### 4. Shared Analysis Type (`frontend/app/types/analysis.ts`)
- New file. `SlideFeedback`, `PresentationAnalysis` — mirrors the backend schema, single source of truth for the hook and components below.

### 5. Analysis Hook (`frontend/app/hooks/useAiAnalysis.ts`)
- New file. `useAiAnalysis()` owns `result` / `isAnalyzing` / `error` state and the `analyze()` API call (errors normalized via the existing `getErrorMessage` util).
- Caches every successful result to `sessionStorage` (`precue_analysis_cache`, keyed by presentation id) — the same client-side caching pattern already used for Topic Ideas' trending-ideas cache. Exposes `getCachedAnalysis()` and `loadCached()` so a previously-analyzed presentation can be re-displayed instantly (from cache, no new AI call) after a page refresh or re-selecting it from the dropdown. Re-analyzing simply overwrites the cached entry — there is no history/trend across multiple runs.

### 6. Quality Analysis Page (`frontend/app/dashboard/analysis/AiAnalysis.tsx`)
- New file. Presentation picker (`<select>`, reusing `AiGenerationForm`'s existing select styling) sourced from `useDashboard().presentations`, filtered to `status === 'completed'`. Analyze / Re-analyze button.
- Persists the selected presentation id to `sessionStorage` (`precue_analysis_selected_id`) and restores both the selection and its cached result on mount, so a full page refresh doesn't lose the last-viewed analysis.
- Two-column layout once a presentation is selected: left column (summary + per-slide feedback, only once an analysis exists), right column (sticky) with the radar chart (once analyzed) and the practice-stats panel (shown immediately, independent of whether an analysis has been run).

### 7. Score Radar Chart (`frontend/app/dashboard/analysis/ScoreRadarChart.tsx`)
- New file. Hand-rolled SVG radar/spider chart (no charting library added — none existed in the project) plotting all 4 scores on 4 axes, gradient-filled polygon (primary → accent), framer-motion scale-in animation, vertex dots colored by a green/amber/red quality threshold, with a colored numeric legend below.

### 8. Practice Stats Panel (`frontend/app/dashboard/analysis/PracticeStats.tsx`, `SessionDurationChart.tsx`)
- New files. Reuses `useDashboard().recentSessions` (already fetched on dashboard mount — zero additional API cost) filtered to the selected presentation: total practice time, rehearsal count, live-session count, last-practiced date, and a colored animated bar chart of the last 10 sessions' durations (rehearsal = cyan, live = orange).

### 9. Wiring (`frontend/app/dashboard/page.tsx`, `frontend/app/dashboard/layout.tsx`)
- Routed `activeTab === 'ai-analysis'` to `<AiAnalysis />` (previously rendered nothing at all — the sidebar entry existed but had no corresponding view).
- Added `ai-analysis` to the compact-header tab list so the section gets a proper title instead of falling back to the default hero header.

### 10. Localization (`frontend/messages/en.json`, `frontend/messages/tr.json`)
- New `aiAnalysis` namespace (title, subtitle, picker/button labels, score labels, practice-stats labels) in both languages.
- Sidebar/header label (`dashboard.aiAnalysis`) changed from "AI Analysis" / "AI Analizi" to **"Quality Analysis" / "Kalite Analizi"** to avoid confusion with the pre-existing `/analyze` page (a different feature — presentation Q&A/chat).

## UX Iterations During Build
- Removed a redundant in-page `<h2>` title that duplicated the compact header's title.
- Removed the decorative icon from the Analyze button, keeping only the functional loading spinner.
- Moved the score cards from a flat top strip into the radar chart's legend to avoid showing the same 4 numbers twice.

## Verification
- Backend: `pytest` (27/27 passing, unaffected), manual live request via the browser confirmed `POST /api/v1/presentations/{id}/analyze` → `200 OK` end-to-end (DB fetch → OpenAI call → response), analyzing a real uploaded PDF and returning content-grounded feedback (not generic/templated output).
- Frontend: `tsc --noEmit` and `eslint app` (whole project) clean after every step; live SSR fetch of `/dashboard?tab=ai-analysis` returns 200 with no error markers.

## Considered, Not Implemented
- **Groq (free-tier) as an alternative to OpenAI for the 4 pure chat-completion services** (`ideas_service`, `analysis_service`, `intent_service`, `rag_service`) was discussed as a cost-reduction option, since the shared `AsyncOpenAI` client (`app/core/openai_client.py`) could point at Groq's OpenAI-compatible endpoint with minimal code change. `embedding_service.py` must stay on OpenAI regardless — Groq has no embeddings API. No code was changed; flagged as a possible follow-up, starting with `intent_service.py` (latency-critical, simple JSON output, most forgiving of a potential quality difference).
